### PR TITLE
fix: Add Streamlit config.toml and secrets.toml files

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,25 @@
+[theme]
+primaryColor="#0096C7"
+backgroundColor="#F0F2F6"
+secondaryBackgroundColor="#FFFFFF"
+textColor="#343A40"
+font="sans serif"
+
+[server]
+# port = 8501
+# headless = true
+# enableCORS = false
+# enableXsrfProtection = true
+
+[browser]
+gatherUsageStats = false
+
+[logger]
+level = "info"
+
+[runner]
+# magicEnabled = true
+# fastReruns = true
+
+[global]
+# dataFrameSerialization = "legacy"

--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,6 @@
+OPENROUTER_API_KEY = "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"
+
+# Example of other potential secrets:
+# DB_USERNAME = "your_db_user"
+# DB_PASSWORD = "your_db_password"
+# OTHER_API_KEY = "another_secret_key"

--- a/pages/super_admin/patient_management.py
+++ b/pages/super_admin/patient_management.py
@@ -229,4 +229,3 @@ if __name__ == "__main__":
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Patient Mgt.")
 
     show_sa_patient_management_page()
-


### PR DESCRIPTION
This commit introduces the standard Streamlit configuration files `.streamlit/config.toml` and `.streamlit/secrets.toml`.

1.  **`.streamlit/config.toml`**:
    *   Populated with default Streamlit settings for theme (primaryColor,
        backgroundColor, etc.), server, browser (gatherUsageStats=false),
        and logger. These provide a base configuration for the app's
        environment.

2.  **`.streamlit/secrets.toml`**:
    *   Created and populated with the `OPENROUTER_API_KEY` as provided.
    *   This file is intended for storing sensitive credentials and should be
        handled securely and typically not committed to public repositories
        if it contains production secrets.

Note: The API key in secrets.toml was provided directly. For production environments, you should consider more secure secret management practices like environment variables or dedicated secret management services.