### PR TITLE
fix: Silence DB init message and correct page loading for sidebar nav

### DIFF
--- a/database/init_db.py
+++ b/database/init_db.py
@@ -868,7 +868,7 @@ def check_and_initialize_database():
                 st.info("Database incomplete. Reinitializing...")
                 return initialize_database()
             else:
-                st.success("Database found and ready!")
+                # st.success("Database found and ready!") # Line removed/commented
                 return True
                 
     except Exception as e:

--- a/pages/assistant/analytics.py
+++ b/pages/assistant/analytics.py
@@ -166,4 +166,7 @@ if __name__ == "__main__":
     if not CHARTS_AVAILABLE: st.sidebar.warning("Using MOCK Chart components for Asst. Analytics.")
     # No specific session state for filters needed at this top level, handled by selectbox key
 
-    show_assistant_analytics_page()
+    # show_assistant_analytics_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_assistant_analytics_page()

--- a/pages/assistant/dashboard.py
+++ b/pages/assistant/dashboard.py
@@ -178,4 +178,7 @@ if __name__ == "__main__":
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
 
-    show_assistant_dashboard()
+    # show_assistant_dashboard() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_assistant_dashboard()

--- a/pages/assistant/lab_tests.py
+++ b/pages/assistant/lab_tests.py
@@ -165,4 +165,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for Asst. Lab Tests.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for Asst. Lab Tests.")
 
-    show_assistant_lab_tests_page()
+    # show_assistant_lab_tests_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_assistant_lab_tests_page()

--- a/pages/assistant/medications.py
+++ b/pages/assistant/medications.py
@@ -161,4 +161,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for Asst. Medications.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for Asst. Medications.")
 
-    show_assistant_medications_page()
+    # show_assistant_medications_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_assistant_medications_page()

--- a/pages/assistant/patient_management.py
+++ b/pages/assistant/patient_management.py
@@ -288,4 +288,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries.")
 
-    show_patient_management_page()
+    # show_patient_management_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_patient_management_page()

--- a/pages/assistant/visit_management.py
+++ b/pages/assistant/visit_management.py
@@ -299,4 +299,7 @@ if __name__ == "__main__":
             if isinstance(date_str_or_obj, (datetime, py_date)): return date_str_or_obj.strftime("%Y-%m-%d")
             return "N/A"
 
-    show_visit_management_page()
+    # show_visit_management_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_visit_management_page()

--- a/pages/doctor/analytics.py
+++ b/pages/doctor/analytics.py
@@ -221,4 +221,7 @@ if __name__ == "__main__":
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
 
-    show_doctor_analytics_page()
+    # show_doctor_analytics_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_doctor_analytics_page()

--- a/pages/doctor/dashboard.py
+++ b/pages/doctor/dashboard.py
@@ -153,4 +153,7 @@ if __name__ == "__main__":
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
 
-    show_doctor_dashboard()
+    # show_doctor_dashboard() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_doctor_dashboard()

--- a/pages/doctor/lab_tests.py
+++ b/pages/doctor/lab_tests.py
@@ -152,4 +152,7 @@ if __name__ == "__main__":
     if 'lab_search_term' not in st.session_state: st.session_state.lab_search_term = ""
     if 'lab_test_category' not in st.session_state: st.session_state.lab_test_category = "All"
 
-    show_lab_tests_page()
+    # show_lab_tests_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_lab_tests_page()

--- a/pages/doctor/medications.py
+++ b/pages/doctor/medications.py
@@ -216,4 +216,7 @@ if __name__ == "__main__":
         mock_toggle_favorite_medication('med001', 'docMedBrowser') # Amoxicillin
         mock_toggle_favorite_medication('med003', 'docMedBrowser') # Lisinopril
 
-    show_medications_page()
+    # show_medications_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_medications_page()

--- a/pages/doctor/prescriptions.py
+++ b/pages/doctor/prescriptions.py
@@ -345,4 +345,7 @@ if __name__ == "__main__":
     if 'rx_lab_tests' not in st.session_state:
         st.session_state.rx_lab_tests = []
 
-    show_prescriptions_page()
+    # show_prescriptions_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_prescriptions_page()

--- a/pages/doctor/templates.py
+++ b/pages/doctor/templates.py
@@ -331,4 +331,7 @@ if __name__ == "__main__":
     if 'duplicating_template_id' not in st.session_state: st.session_state.duplicating_template_id = None
 
     initialize_mock_db() # Populate mock DB for testing
-    show_templates_page()
+    # show_templates_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_templates_page()

--- a/pages/doctor/todays_patients.py
+++ b/pages/doctor/todays_patients.py
@@ -179,4 +179,7 @@ if __name__ == "__main__":
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
 
-    show_todays_patients_page()
+    # show_todays_patients_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_todays_patients_page()

--- a/pages/super_admin/dashboard.py
+++ b/pages/super_admin/dashboard.py
@@ -630,5 +630,20 @@ def render_system_tab():
     else:
         st.success("✅ System is running optimally")
 
+# This call ensures Streamlit runs the page content when navigating
+show_super_admin_dashboard()
+
 if __name__ == "__main__":
-    show_super_admin_dashboard()
+    # Mock setup or specific direct run logic can go here
+    # For example, ensuring a mock user is set if not already by main app flow
+    if 'user' not in st.session_state:
+        st.session_state.user = {
+            'id': 'sa_dashboard_direct',
+            'username': 'sa_dash_direct',
+            'role': USER_ROLES['SUPER_ADMIN'],
+            'full_name': 'SA Dashboard Direct Runner'
+        }
+        st.session_state.authenticated = True
+        st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
+    # show_super_admin_dashboard() # Already called at module level
+    pass

--- a/pages/super_admin/lab_test_management.py
+++ b/pages/super_admin/lab_test_management.py
@@ -275,4 +275,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Lab Test Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Lab Test Mgt.")
 
-    show_sa_lab_test_management_page()
+    # show_sa_lab_test_management_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_sa_lab_test_management_page()

--- a/pages/super_admin/medication_management.py
+++ b/pages/super_admin/medication_management.py
@@ -275,4 +275,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Med Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Med Mgt.")
 
-    show_sa_medication_management_page()
+    # show_sa_medication_management_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_sa_medication_management_page()

--- a/pages/super_admin/patient_management.py
+++ b/pages/super_admin/patient_management.py
@@ -228,4 +228,7 @@ if __name__ == "__main__":
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Patient Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Patient Mgt.")
 
-    show_sa_patient_management_page()
+    # show_sa_patient_management_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_sa_patient_management_page()

--- a/pages/super_admin/system_analytics.py
+++ b/pages/super_admin/system_analytics.py
@@ -236,4 +236,7 @@ if __name__ == "__main__":
     if 'UserQueries' not in globals() or not hasattr(UserQueries, 'get_all_users'):
         class UserQueries: @staticmethod
         def get_all_users(): return [{'id': 'u1', 'username': 'mock_u', 'full_name': 'Mock User', 'role': 'mock_role'}]
-    show_system_analytics_page()
+    # show_system_analytics_page() # Called at module level now
+
+# This call ensures Streamlit runs the page content when navigating
+show_system_analytics_page()

--- a/pages/super_admin/user_management.py
+++ b/pages/super_admin/user_management.py
@@ -562,5 +562,19 @@ def show_user_analytics():
     else:
         st.info("No recent user activity found")
 
+# This call ensures Streamlit runs the page content when navigating
+show_user_management()
+
 if __name__ == "__main__":
-    show_user_management()
+    # Mock setup or specific direct run logic can go here
+    if 'user' not in st.session_state:
+        st.session_state.user = {
+            'id': 'sa_usermgt_direct',
+            'username': 'sa_usermgt_direct',
+            'role': USER_ROLES['SUPER_ADMIN'],
+            'full_name': 'SA UserMgt Direct Runner'
+        }
+        st.session_state.authenticated = True
+        st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
+    # show_user_management() # Already called at module level
+    pass


### PR DESCRIPTION
This commit addresses two of your feedback points:
1.  Silences the "Database found and ready!" message during startup if the database is already initialized. This is achieved by commenting out the specific `st.success` line in `database/init_db.py`.
2.  Corrects the structure of all page files within the `pages/` subdirectories (`doctor`, `assistant`, `super_admin`) to ensure proper loading by Streamlit's multipage app feature. The main rendering function in each page script is now called at the module level, instead of exclusively within an `if __name__ == "__main__":` block. This change should enable the sidebar navigation panel to populate correctly with links to all pages.

These changes aim to improve the application's startup experience and resolve the missing navigation issue.