### PR TITLE
fix: Use markdown links for role-based sidebar navigation

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,13 +31,22 @@ def main():
         # Add custom navigation links
         st.sidebar.markdown("---") # Optional separator
         st.sidebar.header("Navigation")
-        allowed_pages = get_allowed_navigation_items()
+        allowed_pages = get_allowed_navigation_items() # This line should already be there or be similar
+
         for page_info in allowed_pages:
-            st.sidebar.page_link(
-                page_info['path'], 
-                label=page_info['label'], 
-                icon=page_info.get('icon') # Use .get() for icon as it might be optional
-            )
+            # Assuming page_info['path'] is like 'pages/1_doctor_dashboard.py'
+            # We need to extract '1_doctor_dashboard' for the URL
+            try:
+                path_parts = page_info['path'].split('/')
+                filename_with_ext = path_parts[-1] # Should be '1_doctor_dashboard.py'
+                url_component = filename_with_ext.replace('.py', '')
+
+                link_markdown = f"- [{page_info.get('icon', '')} {page_info['label']}]({url_component})"
+                st.sidebar.markdown(link_markdown, unsafe_allow_html=True)
+            except Exception as e:
+                # Log or handle potential errors if path format is unexpected
+                st.sidebar.error(f"Could not create link for {page_info.get('label', 'Unknown page')}")
+
         st.sidebar.markdown("---") # Optional separator
 
         # The main area welcome message can remain

--- a/pages/10_assistant_visit_management.py
+++ b/pages/10_assistant_visit_management.py
@@ -18,9 +18,9 @@ except ImportError:
     class SearchFormComponent: # Mock
         def __init__(self, search_function=None, result_key_prefix=None, form_key=None, placeholder="Search...", label="Search", session_state_key="default_search_term", auto_submit=False, button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_vm_{self.session_state_key}_v3")
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     class VisitFormComponent: # Mock
@@ -36,7 +36,7 @@ except ImportError:
             with st.form(key=f"{self.key_prefix}_form_main_visit_v3"):
                 form_data = {}
                 st.markdown(f"**Patient:** {self.patient_data.get('first_name','N/A')} {self.patient_data.get('last_name','N/A')}")
-                
+
                 current_visit_date_str = self.visit_data.get('visit_date', datetime.now().strftime('%Y-%m-%d'))
                 try:
                     current_visit_date = datetime.strptime(current_visit_date_str, '%Y-%m-%d').date()
@@ -45,9 +45,9 @@ except ImportError:
 
                 form_data['visit_date'] = st.date_input("Visit Date*", value=current_visit_date, key=f"{self.key_prefix}_vdate_v3", min_value=py_date(2000,1,1), max_value=py_date.today() + timedelta(days=365)) # Allow future dates for scheduling
                 form_data['visit_type'] = st.selectbox("Visit Type*", options=["Check-up", "Follow-up", "New Complaint", "Vaccination", "Procedure", "Scheduled Consultation"], index=0, key=f"{self.key_prefix}_vtype_v3")
-                form_data['doctor_assigned_id'] = st.text_input("Doctor Assigned (ID)", value=self.visit_data.get('doctor_assigned_id','doc1'), key=f"{self.key_prefix}_vdoc_v3") 
+                form_data['doctor_assigned_id'] = st.text_input("Doctor Assigned (ID)", value=self.visit_data.get('doctor_assigned_id','doc1'), key=f"{self.key_prefix}_vdoc_v3")
                 form_data['notes'] = st.text_area("Visit Notes / Chief Complaint", value=self.visit_data.get('notes',''), key=f"{self.key_prefix}_vnotes_v3")
-                
+
                 # Vital Signs as a sub-dictionary
                 vital_signs_data = self.visit_data.get('vital_signs',{})
                 form_data['vital_signs'] = {
@@ -60,7 +60,7 @@ except ImportError:
                 submit_label = "Update Visit" if self.edit_mode else "Record Visit"
                 col1, col2 = st.columns([3,1])
                 if col1.form_submit_button(submit_label, use_container_width=True, type="primary"):
-                    valid = True 
+                    valid = True
                     if not form_data.get('visit_date') or not form_data.get('visit_type'): valid = False; show_error_message("Visit Date and Type are required.")
                     if valid: submitted_data = {k: (v.isoformat() if isinstance(v, (py_date, datetime)) else v) for k,v in form_data.items()}
                 if col2.form_submit_button("Cancel", type="secondary", use_container_width=True):
@@ -74,7 +74,7 @@ try:
 except ImportError:
     DB_QUERIES_AVAILABLE = False
     # st.warning("PatientQueries or VisitQueries not found. Using mock data stores.", icon="⚠️") # Moved to __main__
-    MOCK_PATIENTS_VISIT_PAGE = [ 
+    MOCK_PATIENTS_VISIT_PAGE = [
         {'id': 'pat_001', 'first_name': 'John', 'last_name': 'Doe', 'dob': '1985-01-15', 'phone_number': '555-0101', 'created_by': 'assistant123'},
         {'id': 'pat_002', 'first_name': 'Jane', 'last_name': 'Smith', 'dob': '1992-07-22', 'phone_number': '555-0202', 'created_by': 'assistant456'},
         {'id': 'pat_003', 'first_name': 'Alice', 'last_name': 'Johnson', 'dob': '1990-05-20', 'phone_number': '555-0303', 'created_by': 'assistant123'},
@@ -84,9 +84,9 @@ except ImportError:
         {'id': 'visit_002', 'patient_id': 'pat_002', 'patient_name': 'Jane Smith', 'visit_date': (datetime.now() - timedelta(days=2)).isoformat()[:10], 'visit_type': 'Follow-up', 'notes': 'Post-op review', 'created_by': 'assistant456', 'doctor_assigned_id': 'doc2', 'vital_signs': {'bp': '110/70', 'temp_c': 36.8, 'pulse': 65, 'weight_kg': 60.2}},
         {'id': 'visit_003', 'patient_id': 'pat_001', 'patient_name': 'John Doe', 'visit_date': datetime.now().isoformat()[:10], 'visit_type': 'New Complaint', 'notes': 'Sore throat', 'created_by': 'assistant123', 'doctor_assigned_id': 'doc1', 'vital_signs': {'bp': '125/85', 'temp_c': 37.5, 'pulse': 72, 'weight_kg': 75.5}},
     ]
-    class PatientQueries: 
+    class PatientQueries:
         @staticmethod
-        def search_patients(search_term=None, patient_id=None, created_by=None): 
+        def search_patients(search_term=None, patient_id=None, created_by=None):
             results = copy.deepcopy(MOCK_PATIENTS_VISIT_PAGE)
             if patient_id: return [p for p in results if p['id'] == patient_id]
             if search_term:
@@ -97,7 +97,7 @@ except ImportError:
         def get_patient_details(patient_id):
              return next((copy.deepcopy(p) for p in MOCK_PATIENTS_VISIT_PAGE if p['id'] == patient_id), None)
 
-    class VisitQueries: 
+    class VisitQueries:
         @staticmethod
         def search_visits(search_term=None, created_by=None, patient_id=None):
             results = copy.deepcopy(MOCK_VISITS_STORE)
@@ -140,7 +140,7 @@ def handle_create_visit(data, assistant_id):
         new_visit = VisitQueries.create_visit(data, recorded_by_id=assistant_id)
         if new_visit:
             show_success_message(f"Visit for {st.session_state.selected_patient_for_visit['first_name']} recorded (ID: {new_visit['id']}).")
-            st.session_state.visit_form_data = {} 
+            st.session_state.visit_form_data = {}
             # st.session_state.selected_patient_for_visit = None # Keep patient selected for potential next visit for same patient or clear
             # st.session_state.active_visit_management_tab_key = "View & Manage Visits"; st.rerun()
         else: show_error_message("Failed to record visit.")
@@ -182,7 +182,7 @@ def render_view_manage_visits_tab(assistant: dict):
             st.session_state.visit_form_data = full_v_details if full_v_details else visit_data_item
             pat_details = PatientQueries.get_patient_details(visit_data_item['patient_id'])
             st.session_state.selected_patient_for_visit = pat_details
-            st.session_state.active_visit_management_tab_key = "Record / Edit Visit" 
+            st.session_state.active_visit_management_tab_key = "Record / Edit Visit"
             st.rerun()
 
         # Simple display for now, a VisitCard component would be better.
@@ -209,13 +209,13 @@ def render_record_edit_visit_tab(assistant: dict):
                 try: st.session_state.patients_found_for_visit_list = PatientQueries.search_patients(search_term=pat_search_q)
                 except Exception as e: show_error_message(f"Error: {e}"); st.session_state.patients_found_for_visit_list = []
             else: st.info("Enter search term."); st.session_state.patients_found_for_visit_list = []
-        
+
         if 'patients_found_for_visit_list' in st.session_state:
             for p_item in st.session_state.patients_found_for_visit_list:
                 p_name = format_patient_name(p_item.get('first_name'), p_item.get('last_name'))
                 if st.button(f"Select: {p_name} (ID: {p_item['id']})", key=f"sel_pat_v_{p_item['id']}_v3"):
                     st.session_state.selected_patient_for_visit = PatientQueries.get_patient_details(p_item['id'])
-                    st.session_state.patients_found_for_visit_list = [] 
+                    st.session_state.patients_found_for_visit_list = []
                     st.rerun()
             if not st.session_state.patients_found_for_visit_list and pat_search_q: st.info("No patients found.")
 
@@ -234,7 +234,7 @@ def render_record_edit_visit_tab(assistant: dict):
                 st.session_state.active_visit_management_tab_key = "View & Manage Visits"; st.rerun()
             elif is_edit: handle_update_visit(st.session_state.editing_visit_id, submitted_data, assistant['id'])
             else: handle_create_visit(submitted_data, assistant['id'])
-        
+
         cancel_label = "Cancel Edit Mode" if is_edit else "Change Selected Patient / Cancel"
         if st.button(cancel_label, key="cancel_visit_form_btn_main_v3"):
             st.session_state.editing_visit_id = None; st.session_state.visit_form_data = {}; st.session_state.selected_patient_for_visit = None
@@ -248,29 +248,29 @@ def show_visit_management_page():
     require_role_access([USER_ROLES['ASSISTANT']])
     inject_css()
     st.markdown("<h1>🗓️ Patient Visit Management</h1>", unsafe_allow_html=True)
-    
+
     curr_user = get_current_user()
     if not curr_user: show_error_message("User data not found."); return
 
     # Initialize session states
     for key, default_val in [('selected_patient_for_visit', None), ('editing_visit_id', None),
-                             ('visit_form_data', {}), ('visit_search_term_main_v3', ""), 
-                             ('visit_patient_search_term_main_v3', ""), 
+                             ('visit_form_data', {}), ('visit_search_term_main_v3', ""),
+                             ('visit_patient_search_term_main_v3', ""),
                              ('active_visit_management_tab_key', "View & Manage Visits"),
                              ('patients_found_for_visit_list', [])]:
         if key not in st.session_state: st.session_state[key] = default_val
-    
+
     tab_list = ["View & Manage Visits", "Record / Edit Visit"]
     if st.session_state.editing_visit_id or st.session_state.selected_patient_for_visit:
         st.session_state.active_visit_management_tab_key = tab_list[1] # Default to this tab if state implies it
-    
+
     # This simple tab switch method relies on reruns caused by other actions setting the state.
     # More direct tab switching in Streamlit is complex.
     active_tab_index = tab_list.index(st.session_state.active_visit_management_tab_key) if st.session_state.active_visit_management_tab_key in tab_list else 0
-    
+
     # We are not using default_index in st.tabs as it's not a direct parameter.
     # The content within tabs will handle visibility based on session state.
-    tabs_display = st.tabs(tab_list) 
+    tabs_display = st.tabs(tab_list)
 
     with tabs_display[0]: render_view_manage_visits_tab(curr_user)
     with tabs_display[1]: render_record_edit_visit_tab(curr_user)
@@ -281,15 +281,15 @@ if __name__ == "__main__":
         st.session_state.authenticated = True; st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
 
     for key, default_val in [('selected_patient_for_visit', None), ('editing_visit_id', None),
-                             ('visit_form_data', {}), ('visit_search_term_main_v3', ""), 
-                             ('visit_patient_search_term_main_v3', ""), 
+                             ('visit_form_data', {}), ('visit_search_term_main_v3', ""),
+                             ('visit_patient_search_term_main_v3', ""),
                              ('active_visit_management_tab_key', "View & Manage Visits"),
                              ('patients_found_for_visit_list', [])]:
         if key not in st.session_state: st.session_state[key] = default_val
 
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for Visit Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for Visit Mgt.")
-    
+
     # Ensure mock formatters are available if not imported from utils
     if 'format_patient_name' not in globals() or not callable(globals()['format_patient_name']):
         def format_patient_name(first, last): return f"{first or ''} {last or ''}".strip()

--- a/pages/11_assistant_medications.py
+++ b/pages/11_assistant_medications.py
@@ -16,12 +16,12 @@ try:
 except ImportError:
     COMPONENTS_AVAILABLE = False
     # Mock SearchFormComponent
-    class SearchFormComponent: 
+    class SearchFormComponent:
         def __init__(self, search_function=None, result_key_prefix=None, form_key=None, placeholder="Search...", label="Search", session_state_key="default_search_term", auto_submit=False, button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_asst_med_{self.session_state_key}_v2")
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     # Mock MedicationCard - simplified for assistant view (no favorite actions)
@@ -44,7 +44,7 @@ try:
     DB_QUERIES_AVAILABLE = True
 except ImportError:
     DB_QUERIES_AVAILABLE = False
-    MOCK_MEDS_STORE_ASST = [ 
+    MOCK_MEDS_STORE_ASST = [
         {'id': 'med001', 'name': 'Amoxicillin 250mg', 'generic_name': 'Amoxicillin', 'drug_class': 'Penicillin Antibiotics', 'form': 'Capsule', 'strength': '250mg', 'indications': ['Bacterial infections'], 'notes': 'Complete full course.'},
         {'id': 'med002', 'name': 'Paracetamol 500mg', 'generic_name': 'Acetaminophen', 'drug_class': 'Analgesics', 'form': 'Tablet', 'strength': '500mg', 'indications': ['Pain relief', 'Fever reduction'], 'notes': 'Max 4g/day.'},
         {'id': 'med003', 'name': 'Lisinopril 10mg', 'generic_name': 'Lisinopril', 'drug_class': 'ACE Inhibitors', 'form': 'Tablet', 'strength': '10mg', 'indications': ['Hypertension'], 'notes': 'Monitor blood pressure.'},
@@ -53,7 +53,7 @@ except ImportError:
     ]
     class MedicationQueries:
         @staticmethod
-        def search_medications(search_term=None, drug_class=None, favorites_only=None, doctor_id=None): 
+        def search_medications(search_term=None, drug_class=None, favorites_only=None, doctor_id=None):
             results = copy.deepcopy(MOCK_MEDS_STORE_ASST)
             if search_term:
                 term = search_term.lower()
@@ -68,7 +68,7 @@ from utils.helpers import show_error_message, show_success_message, show_warning
 # --- UI Rendering Functions ---
 def render_assistant_medication_search():
     st.subheader("🔍 Search & Filter Medications")
-    
+
     search_form = SearchFormComponent(session_state_key="asst_med_search_term_v2", label="Search by Name or Generic Name:")
     search_form.render()
 
@@ -76,35 +76,35 @@ def render_assistant_medication_search():
     with filter_cols[0]:
         available_drug_classes = DRUG_CLASSES if isinstance(DRUG_CLASSES, list) and DRUG_CLASSES else ["Analgesics", "Antibiotics", "NSAIDs", "ACE Inhibitors", "Biguanides", "Penicillin Antibiotics", "Other"]
         all_drug_classes_options = ["All"] + sorted(list(set(available_drug_classes)))
-        
+
         current_drug_class = st.session_state.get('asst_med_drug_class_v2', "All")
         if current_drug_class not in all_drug_classes_options: current_drug_class_index = 0
         else: current_drug_class_index = all_drug_classes_options.index(current_drug_class)
-        
+
         st.session_state.asst_med_drug_class_v2 = st.selectbox(
-            "Filter by Drug Class:", 
-            options=all_drug_classes_options, 
+            "Filter by Drug Class:",
+            options=all_drug_classes_options,
             index=current_drug_class_index,
             key="asst_med_drug_class_filter_v2"
         )
     with filter_cols[1]:
-        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) 
+        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True)
         if st.button("🔄 Refresh / Apply", key="asst_med_refresh_btn_v2", use_container_width=True):
             st.rerun()
     st.markdown("---")
 
 def render_assistant_medications_list():
     st.subheader("Medication Listings")
-    
+
     search_term_val = st.session_state.get('asst_med_search_term_v2', "")
     drug_class_filter_val = st.session_state.get('asst_med_drug_class_v2', "All")
 
     try:
         medications_data = MedicationQueries.search_medications(
-            search_term=search_term_val, 
+            search_term=search_term_val,
             drug_class=drug_class_filter_val
         )
-    except AttributeError: 
+    except AttributeError:
         show_warning_message("Medication query service initializing. Using mock data.", icon="⚠️")
         medications_data = MedicationQueries.search_medications(search_term_val, drug_class_filter_val)
     except Exception as e:
@@ -115,7 +115,7 @@ def render_assistant_medications_list():
         st.info("No medications found matching your criteria.")
         return
 
-    num_cols = 3 
+    num_cols = 3
     item_cols = st.columns(num_cols)
     for i, med_data_item in enumerate(medications_data):
         with item_cols[i % num_cols]:
@@ -124,7 +124,7 @@ def render_assistant_medications_list():
             # If a real MedicationCard is used, it needs to respect show_actions=False or have a mode for assistants.
             try:
                 MedicationCard(medication_data=med_data_item, actions=None, key=f"asst_med_card_{med_data_item['id']}_v2", show_actions=False)
-            except TypeError: 
+            except TypeError:
                  MedicationCard(medication_data=med_data_item, key=f"asst_med_card_{med_data_item['id']}_alt_v2") # Try without show_actions if TypeError
             except Exception as e:
                 st.error(f"Error rendering card for {med_data_item.get('name')}: {e}")
@@ -138,7 +138,7 @@ def show_assistant_medications_page():
 
     st.markdown("<h1>💊 Medications Database (Assistant View)</h1>", unsafe_allow_html=True)
     st.caption("This is a read-only view of the medications database. Contact a doctor or pharmacist for detailed advice.")
-    
+
     if 'asst_med_search_term_v2' not in st.session_state: st.session_state.asst_med_search_term_v2 = ""
     if 'asst_med_drug_class_v2' not in st.session_state: st.session_state.asst_med_drug_class_v2 = "All"
 
@@ -148,7 +148,7 @@ def show_assistant_medications_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'asstMedBrowser007', 'username': 'asst_medview007', 
+            'id': 'asstMedBrowser007', 'username': 'asst_medview007',
             'role': USER_ROLES['ASSISTANT'], 'full_name': 'Alex View (Med Asst)',
             'email': 'alex.medasst.view@example.com'
         }
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
     if 'asst_med_search_term_v2' not in st.session_state: st.session_state.asst_med_search_term_v2 = ""
     if 'asst_med_drug_class_v2' not in st.session_state: st.session_state.asst_med_drug_class_v2 = "All"
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for Asst. Medications.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for Asst. Medications.")
 

--- a/pages/12_assistant_lab_tests.py
+++ b/pages/12_assistant_lab_tests.py
@@ -16,16 +16,16 @@ try:
 except ImportError:
     COMPONENTS_AVAILABLE = False
     # Mock SearchFormComponent
-    class SearchFormComponent: 
+    class SearchFormComponent:
         def __init__(self, search_function=None, result_key_prefix=None, form_key=None, placeholder="Search...", label="Search", session_state_key="default_search_term", auto_submit=False, button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_asst_lab_{self.session_state_key}_v2")
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     # Mock LabTestCard - simplified for assistant view
-    def LabTestCard(lab_test_data, actions=None, key=None, show_actions=True): 
+    def LabTestCard(lab_test_data, actions=None, key=None, show_actions=True):
         st.markdown(f"**{lab_test_data.get('name', 'N/A')}**")
         st.caption(f"Category: {lab_test_data.get('category', 'N/A')} | Specimen: {lab_test_data.get('specimen_type', 'N/A')}")
         if show_actions and actions: # This part won't be used for assistant if actions=None or show_actions=False
@@ -68,7 +68,7 @@ from utils.helpers import show_error_message, show_success_message, show_warning
 # --- UI Rendering Functions ---
 def render_assistant_lab_test_search():
     st.subheader("🔍 Search & Filter Lab Tests")
-    
+
     search_form = SearchFormComponent(session_state_key="asst_lab_search_term_v2", label="Search by Name or Description:")
     search_form.render()
 
@@ -80,37 +80,37 @@ def render_assistant_lab_test_search():
             available_categories = default_categories
         else:
             available_categories = config_categories
-            
+
         all_category_options = ["All"] + sorted(list(set(available_categories)))
-        
+
         current_category = st.session_state.get('asst_lab_category_v2', "All")
         if current_category not in all_category_options: current_category_index = 0
         else: current_category_index = all_category_options.index(current_category)
-        
+
         st.session_state.asst_lab_category_v2 = st.selectbox(
-            "Filter by Test Category:", 
-            options=all_category_options, 
+            "Filter by Test Category:",
+            options=all_category_options,
             index=current_category_index,
             key="asst_lab_category_filter_v2"
         )
     with filter_cols[1]:
-        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) 
+        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True)
         if st.button("🔄 Refresh / Apply", key="asst_lab_refresh_btn_v2", use_container_width=True):
             st.rerun()
     st.markdown("---")
 
 def render_assistant_lab_tests_list():
     st.subheader("Lab Test Listings")
-    
+
     search_term_val = st.session_state.get('asst_lab_search_term_v2', "")
     category_filter_val = st.session_state.get('asst_lab_category_v2', "All")
 
     try:
         lab_tests_data = LabTestQueries.search_lab_tests(
-            search_term=search_term_val, 
+            search_term=search_term_val,
             category=category_filter_val
         )
-    except AttributeError: 
+    except AttributeError:
         show_warning_message("Lab Test query service initializing. Using mock data.", icon="⚠️")
         lab_tests_data = LabTestQueries.search_lab_tests(search_term_val, category_filter_val)
     except Exception as e:
@@ -121,7 +121,7 @@ def render_assistant_lab_tests_list():
         st.info("No lab tests found matching your criteria.")
         return
 
-    num_cols = 3 
+    num_cols = 3
     item_cols = st.columns(num_cols)
     for i, test_data_item in enumerate(lab_tests_data):
         with item_cols[i % num_cols]:
@@ -142,7 +142,7 @@ def show_assistant_lab_tests_page():
 
     st.markdown("<h1>🧪 Lab Tests Database (Assistant View)</h1>", unsafe_allow_html=True)
     st.caption("This is a read-only view of the lab tests database.")
-    
+
     if 'asst_lab_search_term_v2' not in st.session_state: st.session_state.asst_lab_search_term_v2 = ""
     if 'asst_lab_category_v2' not in st.session_state: st.session_state.asst_lab_category_v2 = "All"
 
@@ -152,7 +152,7 @@ def show_assistant_lab_tests_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'asstLabBrowser008', 'username': 'asst_labview008', 
+            'id': 'asstLabBrowser008', 'username': 'asst_labview008',
             'role': USER_ROLES['ASSISTANT'], 'full_name': 'Alex LabView (Med Asst)',
             'email': 'alex.medasst.labview@example.com' # Unique email
         }
@@ -161,7 +161,7 @@ if __name__ == "__main__":
 
     if 'asst_lab_search_term_v2' not in st.session_state: st.session_state.asst_lab_search_term_v2 = ""
     if 'asst_lab_category_v2' not in st.session_state: st.session_state.asst_lab_category_v2 = "All"
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for Asst. Lab Tests.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for Asst. Lab Tests.")
 

--- a/pages/13_assistant_analytics.py
+++ b/pages/13_assistant_analytics.py
@@ -13,21 +13,21 @@ try:
     from services.analytics_service import AnalyticsService
 except ImportError:
     class AnalyticsService: # Mock service
-        def get_patient_analytics(self, role, user_id, days_back): 
+        def get_patient_analytics(self, role, user_id, days_back):
             # st.warning("AnalyticsService (get_patient_analytics) not found. Using mock data.", icon="⚠️") # Less verbose for final
             end_date = datetime.now()
             start_date = end_date - timedelta(days=days_back)
             date_range = pd.date_range(start_date, end_date, freq='D')
             registrations_count = [max(0, int(3 + 2 * (i % 5) - (i % 2)**2 + i//7 + hash(user_id)%3)) for i in range(len(date_range))]
             return {
-                'patient_registrations_timeline': pd.DataFrame({ 
+                'patient_registrations_timeline': pd.DataFrame({
                     'date': date_range,
                     'count': registrations_count
                 }),
                 'total_patients_registered': sum(registrations_count)
             }
 
-        def get_visit_analytics(self, role, user_id, days_back): 
+        def get_visit_analytics(self, role, user_id, days_back):
             # st.warning("AnalyticsService (get_visit_analytics) not found. Using mock data.", icon="⚠️") # Less verbose for final
             end_date = datetime.now()
             start_date = end_date - timedelta(days=days_back)
@@ -47,24 +47,24 @@ except ImportError:
             }
 
 try:
-    from components.charts import TimeSeriesChart, BarChart 
+    from components.charts import TimeSeriesChart, BarChart
     CHARTS_AVAILABLE = True
 except ImportError:
     CHARTS_AVAILABLE = False
-    def TimeSeriesChart(data, title=None, x_axis='date', y_axis='count'): 
+    def TimeSeriesChart(data, title=None, x_axis='date', y_axis='count'):
         if title: st.caption(title)
         if isinstance(data, pd.DataFrame) and not data.empty and x_axis in data.columns and y_axis in data.columns:
             st.line_chart(data.set_index(x_axis)[y_axis])
         else: st.info(f"No data or incorrect format for TimeSeriesChart: {title if title else ''}.")
 
-    def BarChart(data, title=None, x_axis=None, y_axis=None): 
+    def BarChart(data, title=None, x_axis=None, y_axis=None):
         if title: st.caption(title)
         if isinstance(data, pd.DataFrame) and not data.empty:
             if x_axis is None and len(data.columns) > 0: x_axis = data.columns[0]
             if y_axis is None and len(data.columns) > 1: y_axis = data.columns[1]
             if x_axis in data.columns and y_axis in data.columns: st.bar_chart(data.set_index(x_axis)[y_axis])
             elif x_axis in data.columns : st.bar_chart(data.set_index(x_axis))
-            else: st.bar_chart(data) 
+            else: st.bar_chart(data)
         else: st.info(f"No data or incorrect format for BarChart: {title if title else ''}.")
 
 # Utils
@@ -82,13 +82,13 @@ def render_assistant_analytics_content(assistant: dict):
             options=[7, 15, 30, 60, 90],
             format_func=lambda x: f"Last {x} days",
             index=2, # Default to 30 days
-            key="asst_analytics_period_select_v2" 
+            key="asst_analytics_period_select_v2"
         )
     with col3:
-        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) 
+        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True)
         if st.button("🔄 Refresh Data", key="refresh_asst_analytics_v2", use_container_width=True):
             st.rerun()
-    
+
     st.markdown("---")
 
     try:
@@ -104,7 +104,7 @@ def render_assistant_analytics_content(assistant: dict):
     if patient_reg_analytics and isinstance(patient_reg_analytics, dict):
         total_registered = patient_reg_analytics.get('total_patients_registered', 0)
         st.metric(label=f"Total Patients Registered (Last {selected_period_days} days)", value=total_registered if total_registered is not None else "N/A")
-        
+
         reg_timeline_data = patient_reg_analytics.get('patient_registrations_timeline')
         if isinstance(reg_timeline_data, pd.DataFrame) and not reg_timeline_data.empty:
             TimeSeriesChart(reg_timeline_data, title="Registration Trend", x_axis='date', y_axis='count')
@@ -112,7 +112,7 @@ def render_assistant_analytics_content(assistant: dict):
             st.info("No patient registration trend data available for this period.")
     else:
         st.info("No patient registration analytics available or data is in an unexpected format.")
-    
+
     st.markdown("---")
 
     st.subheader("🗓️ Visit Recordings by You")
@@ -125,7 +125,7 @@ def render_assistant_analytics_content(assistant: dict):
             TimeSeriesChart(visit_timeline_data, title="Visit Recording Trend", x_axis='date', y_axis='count')
         else:
             st.info("No visit recording trend data available for this period.")
-        
+
         st.markdown("##### Visit Types Recorded by You")
         visit_types_data = visit_rec_analytics.get('visit_types_distribution')
         if isinstance(visit_types_data, pd.DataFrame) and not visit_types_data.empty:
@@ -143,7 +143,7 @@ def show_assistant_analytics_page():
     inject_css()
 
     st.markdown("<h1>📊 My Activity Analytics</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if not current_user:
         show_error_message("Unable to retrieve user information. Please log in again.")
@@ -155,14 +155,14 @@ if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
             'id': 'asstAnalyticsUser002', # Changed ID for testing
-            'username': 'asst_analyzer002', 
-            'role': USER_ROLES['ASSISTANT'], 
+            'username': 'asst_analyzer002',
+            'role': USER_ROLES['ASSISTANT'],
             'full_name': 'Drew Analyzer (Asst.)', # Changed name
             'email': 'drew.analyzer.asst@example.com'
         }
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
-    
+
     if not CHARTS_AVAILABLE: st.sidebar.warning("Using MOCK Chart components for Asst. Analytics.")
     # No specific session state for filters needed at this top level, handled by selectbox key
 

--- a/pages/14_super_admin_dashboard.py
+++ b/pages/14_super_admin_dashboard.py
@@ -638,9 +638,9 @@ if __name__ == "__main__":
     # For example, ensuring a mock user is set if not already by main app flow
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'sa_dashboard_direct', 
-            'username': 'sa_dash_direct', 
-            'role': USER_ROLES['SUPER_ADMIN'], 
+            'id': 'sa_dashboard_direct',
+            'username': 'sa_dash_direct',
+            'role': USER_ROLES['SUPER_ADMIN'],
             'full_name': 'SA Dashboard Direct Runner'
         }
         st.session_state.authenticated = True

--- a/pages/15_super_admin_user_management.py
+++ b/pages/15_super_admin_user_management.py
@@ -569,9 +569,9 @@ if __name__ == "__main__":
     # Mock setup or specific direct run logic can go here
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'sa_usermgt_direct', 
-            'username': 'sa_usermgt_direct', 
-            'role': USER_ROLES['SUPER_ADMIN'], 
+            'id': 'sa_usermgt_direct',
+            'username': 'sa_usermgt_direct',
+            'role': USER_ROLES['SUPER_ADMIN'],
             'full_name': 'SA UserMgt Direct Runner'
         }
         st.session_state.authenticated = True

--- a/pages/16_super_admin_patient_management.py
+++ b/pages/16_super_admin_patient_management.py
@@ -14,17 +14,17 @@ try:
     COMPONENTS_AVAILABLE = True
 except ImportError:
     COMPONENTS_AVAILABLE = False
-    class SearchFormComponent: 
+    class SearchFormComponent:
         def __init__(self, search_function=None, result_key_prefix=None, form_key=None, placeholder="Search...", label="Search", session_state_key="default_search_term", auto_submit=False, button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_sa_pat_{self.session_state_key}_v2") # Key updated
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     class PatientFormComponent:
         def __init__(self, edit_mode=False, patient_data=None, key_prefix="sa_patient_form", required_fields=None):
-            self.edit_mode = edit_mode 
+            self.edit_mode = edit_mode
             self.patient_data = patient_data if patient_data else {}
             self.key_prefix = key_prefix
             self.required_fields = required_fields or ['first_name', 'last_name', 'dob', 'phone_number']
@@ -36,7 +36,7 @@ except ImportError:
                 form_data = {}
                 form_data['first_name'] = st.text_input("First Name*", value=self.patient_data.get('first_name', ''), key=f"{self.key_prefix}_fname_sa_v2") # Key updated
                 form_data['last_name'] = st.text_input("Last Name*", value=self.patient_data.get('last_name', ''), key=f"{self.key_prefix}_lname_sa_v2") # Key updated
-                
+
                 dob_val = self.patient_data.get('dob')
                 if isinstance(dob_val, str):
                     try: dob_val = datetime.strptime(dob_val, '%Y-%m-%d').date()
@@ -52,7 +52,7 @@ except ImportError:
                 form_data['allergies'] = st.text_area("Allergies", value=self.patient_data.get('allergies', ''), key=f"{self.key_prefix}_allergies_sa_v2")
                 form_data['medical_history'] = st.text_area("Medical History Summary", value=self.patient_data.get('medical_history', ''), key=f"{self.key_prefix}_medhist_sa_v2")
 
-                
+
                 submit_btn_label = "Update Patient Details"
                 col1, col2 = st.columns([3,1])
                 if col1.form_submit_button(submit_btn_label, use_container_width=True, type="primary"):
@@ -67,7 +67,7 @@ except ImportError:
 try:
     from components.cards import PatientCard
 except ImportError:
-    def PatientCard(patient_data, actions, key): 
+    def PatientCard(patient_data, actions, key):
         st.markdown(f"**{patient_data.get('first_name', 'N/A')} {patient_data.get('last_name', 'N/A')}** (ID: {patient_data.get('id', 'N/A')})")
         st.caption(f"DOB: {patient_data.get('dob', 'N/A')} | Phone: {patient_data.get('phone_number', 'N/A')} | Created By: {patient_data.get('created_by', 'N/A')}")
         for action_label, action_func in actions.items():
@@ -87,7 +87,7 @@ except ImportError:
     ]
     class PatientQueries:
         @staticmethod
-        def search_patients(search_term=None, patient_id=None, created_by=None): 
+        def search_patients(search_term=None, patient_id=None, created_by=None):
             results = copy.deepcopy(MOCK_PATIENTS_STORE_SA)
             if patient_id: return [p for p in results if p['id'] == patient_id]
             if search_term: # Super Admin search ignores created_by
@@ -95,13 +95,13 @@ except ImportError:
                 results = [p for p in results if term in p['first_name'].lower() or term in p['last_name'].lower() or term in p.get('phone_number','') or term in p.get('email','')]
             return results
         @staticmethod
-        def get_patient_details(patient_id): 
+        def get_patient_details(patient_id):
             return next((copy.deepcopy(p) for p in MOCK_PATIENTS_STORE_SA if p['id'] == patient_id), None)
         @staticmethod
-        def update_patient(patient_id, data, updated_by_id): 
+        def update_patient(patient_id, data, updated_by_id):
             for i, p_item in enumerate(MOCK_PATIENTS_STORE_SA):
                 if p_item['id'] == patient_id:
-                    original_creator = p_item.get('created_by') 
+                    original_creator = p_item.get('created_by')
                     MOCK_PATIENTS_STORE_SA[i] = {**p_item, **data, 'last_updated_by': updated_by_id, 'updated_at': datetime.now().isoformat()}
                     if 'created_by' not in data: MOCK_PATIENTS_STORE_SA[i]['created_by'] = original_creator
                     return MOCK_PATIENTS_STORE_SA[i]
@@ -116,10 +116,10 @@ def handle_sa_update_patient(patient_id, data, admin_id):
         updated_patient = PatientQueries.update_patient(patient_id, data, updated_by_id=admin_id)
         if updated_patient:
             show_success_message(f"Patient {updated_patient['first_name']} {updated_patient['last_name']} updated by Admin.")
-            st.session_state.sa_editing_patient_id_v2 = None 
+            st.session_state.sa_editing_patient_id_v2 = None
             st.session_state.sa_patient_form_data_v2 = {}
-            st.session_state.active_sa_patient_management_tab_v2 = "Search & Manage Patients" 
-            st.rerun() 
+            st.session_state.active_sa_patient_management_tab_v2 = "Search & Manage Patients"
+            st.rerun()
         else: show_error_message("Failed to update patient information.")
     except Exception as e: show_error_message(f"Error updating patient: {e}")
 
@@ -135,23 +135,23 @@ def render_sa_search_manage_patients_tab(admin_user: dict):
 
     patients_data = []
     if perform_search_now or not search_query: # If button clicked or no search query (show all)
-        try: patients_data = PatientQueries.search_patients(search_term=search_query) 
+        try: patients_data = PatientQueries.search_patients(search_term=search_query)
         except Exception as e: show_error_message(f"Error searching patients: {e}")
 
-    total_system_patients = len(PatientQueries.search_patients()) 
+    total_system_patients = len(PatientQueries.search_patients())
     st.caption(f"Displaying {len(patients_data)} of {total_system_patients} total patients in system.")
 
     if not patients_data and search_query: st.info(f"No patients found matching '{search_query}'.")
     elif not patients_data and not search_query : st.info("No patients in the system yet.") # Only if DB is empty
-    
+
     for p_item_data in patients_data:
-        def edit_action_sa(patient_data_item=p_item_data): 
+        def edit_action_sa(patient_data_item=p_item_data):
             st.session_state.sa_editing_patient_id_v2 = patient_data_item['id'] # Key updated
             full_details_sa = PatientQueries.get_patient_details(patient_data_item['id'])
             st.session_state.sa_patient_form_data_v2 = full_details_sa if full_details_sa else patient_data_item # Key updated
             st.session_state.active_sa_patient_management_tab_v2 = "Edit Patient Details"  # Key updated
             st.rerun()
-        
+
         actions_for_card = {"Edit Patient Details": edit_action_sa}
         PatientCard(patient_data=p_item_data, actions=actions_for_card, key=f"sa_pat_card_{p_item_data['id']}_v2") # Key updated
         st.markdown("---")
@@ -177,14 +177,14 @@ def render_sa_edit_patient_tab(admin_user: dict):
             st.session_state.active_sa_patient_management_tab_v2 = "Search & Manage Patients"; st.rerun() # Key updated
         else:
             handle_sa_update_patient(st.session_state.sa_editing_patient_id_v2, submitted_patient_data, admin_user['id']) # Key updated
-    
+
 # --- Main Page Function ---
 def show_sa_patient_management_page():
     require_authentication()
     require_role_access([USER_ROLES['SUPER_ADMIN']])
     inject_css()
     st.markdown("<h1>👥 All Patients (Super Admin View)</h1>", unsafe_allow_html=True)
-    
+
     admin = get_current_user()
     if not admin: show_error_message("Admin user data not found."); return
 
@@ -192,11 +192,11 @@ def show_sa_patient_management_page():
     if 'sa_editing_patient_id_v2' not in st.session_state: st.session_state.sa_editing_patient_id_v2 = None
     if 'sa_patient_form_data_v2' not in st.session_state: st.session_state.sa_patient_form_data_v2 = {}
     if 'sa_patient_search_term_v2' not in st.session_state: st.session_state.sa_patient_search_term_v2 = ""
-    if 'active_sa_patient_management_tab_v2' not in st.session_state: 
+    if 'active_sa_patient_management_tab_v2' not in st.session_state:
         st.session_state.active_sa_patient_management_tab_v2 = "Search & Manage Patients"
 
     tab_titles_sa = ["Search & Manage Patients", "Edit Patient Details"]
-    
+
     # Logic to determine which tab should be "active" based on session state
     # This doesn't directly set st.tabs' active tab, but ensures content is ready for when user clicks or page reruns
     if st.session_state.sa_editing_patient_id_v2:
@@ -204,7 +204,7 @@ def show_sa_patient_management_page():
         # Streamlit's st.tabs doesn't have a programmatic way to set the active tab after initial render without workarounds.
         # The content of the tabs will be conditional on session state.
         pass # The content of render_sa_edit_patient_tab will handle being visible.
-    
+
     tab1_sa, tab2_sa = st.tabs(tab_titles_sa)
 
     with tab1_sa:
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     if 'sa_patient_form_data_v2' not in st.session_state: st.session_state.sa_patient_form_data_v2 = {}
     if 'sa_patient_search_term_v2' not in st.session_state: st.session_state.sa_patient_search_term_v2 = ""
     if 'active_sa_patient_management_tab_v2' not in st.session_state: st.session_state.active_sa_patient_management_tab_v2 = "Search & Manage Patients"
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Patient Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Patient Mgt.")
 

--- a/pages/17_super_admin_medication_management.py
+++ b/pages/17_super_admin_medication_management.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import copy
 
 # Config and Auth
-from config.settings import USER_ROLES, DRUG_CLASSES 
+from config.settings import USER_ROLES, DRUG_CLASSES
 from config.styles import inject_css
 from auth.authentication import require_authentication, get_current_user
 from auth.permissions import require_role_access
@@ -15,12 +15,12 @@ try:
     COMPONENTS_AVAILABLE = True
 except ImportError:
     COMPONENTS_AVAILABLE = False
-    class SearchFormComponent: 
+    class SearchFormComponent:
         def __init__(self, search_function=None,result_key_prefix=None,form_key=None,placeholder="Search...",label="Search",session_state_key="default_search_term",auto_submit=False,button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_sa_med_mgt_{self.session_state_key}_v2") # Key updated
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     class MedicationFormComponent:
@@ -37,13 +37,13 @@ except ImportError:
                 form_data = {}
                 form_data['name'] = st.text_input("Medication Name*", value=self.med_data.get('name', ''), key=f"{self.key_prefix}_name_v2") # Key updated
                 form_data['generic_name'] = st.text_input("Generic Name*", value=self.med_data.get('generic_name', ''), key=f"{self.key_prefix}_gen_name_v2") # Key updated
-                
+
                 available_drug_classes = DRUG_CLASSES if isinstance(DRUG_CLASSES, list) and DRUG_CLASSES else ["Analgesics", "Antibiotics", "NSAIDs", "ACE Inhibitors", "Other"]
                 current_drug_class_idx = 0
                 if self.med_data.get('drug_class') in available_drug_classes:
                     current_drug_class_idx = available_drug_classes.index(self.med_data['drug_class'])
                 form_data['drug_class'] = st.selectbox("Drug Class*", options=available_drug_classes, index=current_drug_class_idx, key=f"{self.key_prefix}_drug_class_v2") # Key updated
-                
+
                 form_data['form'] = st.text_input("Form (e.g., Tablet, Capsule)*", value=self.med_data.get('form', ''), key=f"{self.key_prefix}_form_v2") # Key updated
                 form_data['strength'] = st.text_input("Strength (e.g., 10mg, 500mg/5ml)*", value=self.med_data.get('strength', ''), key=f"{self.key_prefix}_strength_v2") # Key updated
                 form_data['manufacturer'] = st.text_input("Manufacturer", value=self.med_data.get('manufacturer', ''), key=f"{self.key_prefix}_mfr_v2") # Key updated
@@ -60,7 +60,7 @@ except ImportError:
                     valid = True
                     for field in self.required:
                         if not form_data.get(field): valid = False; show_error_message(f"{field.replace('_',' ').title()} is required.")
-                    if valid: 
+                    if valid:
                         form_data['indications'] = [i.strip() for i in form_data['indications'].split(',') if i.strip()]
                         form_data['contraindications'] = [c.strip() for c in form_data['contraindications'].split(',') if c.strip()]
                         submitted_data = form_data
@@ -68,7 +68,7 @@ except ImportError:
                     submitted_data = {"cancelled": True}
             return submitted_data
 
-    def MedicationCard(medication_data, actions, key, show_actions=True): 
+    def MedicationCard(medication_data, actions, key, show_actions=True):
         status = "Active" if medication_data.get('is_active', True) else "Inactive"
         st.markdown(f"**{medication_data.get('name', 'N/A')}** ({status})")
         st.caption(f"Generic: {medication_data.get('generic_name', 'N/A')} | Class: {medication_data.get('drug_class', 'N/A')}")
@@ -90,20 +90,20 @@ except ImportError:
     ]
     class MedicationQueries:
         @staticmethod
-        def search_medications(search_term=None, drug_class=None, is_active=None, favorites_only=None, doctor_id=None): 
+        def search_medications(search_term=None, drug_class=None, is_active=None, favorites_only=None, doctor_id=None):
             results = copy.deepcopy(MOCK_MEDS_DB_SA)
             if search_term: term = search_term.lower(); results = [m for m in results if term in m['name'].lower() or term in m.get('generic_name','').lower()]
             if drug_class and drug_class != "All": results = [m for m in results if m.get('drug_class') == drug_class]
             if is_active is not None: results = [m for m in results if m.get('is_active') == is_active]
             return sorted(results, key=lambda x: x['name']) # Sort alphabetically
         @staticmethod
-        def get_medication_details(medication_id): 
+        def get_medication_details(medication_id):
             return next((copy.deepcopy(m) for m in MOCK_MEDS_DB_SA if m['id'] == medication_id), None)
         @staticmethod
         def create_medication(data, created_by_id):
             new_id = f"med_sa_{len(MOCK_MEDS_DB_SA) + 1:03d}_{datetime.now().strftime('%S%f')}"
             new_med = {'id': new_id, **data, 'created_by': created_by_id, 'created_at': datetime.now().isoformat()}
-            if 'is_active' not in new_med: new_med['is_active'] = True 
+            if 'is_active' not in new_med: new_med['is_active'] = True
             MOCK_MEDS_DB_SA.append(new_med)
             return new_med
         @staticmethod
@@ -132,7 +132,7 @@ def handle_sa_create_medication(data, admin_id):
         new_med = MedicationQueries.create_medication(data, created_by_id=admin_id)
         if new_med:
             show_success_message(f"Medication '{new_med['name']}' added (ID: {new_med['id']}).")
-            st.session_state.sa_med_form_data_v2 = {} 
+            st.session_state.sa_med_form_data_v2 = {}
             st.session_state.sa_editing_med_id_v2 = None # Go back to manage view after adding
             st.session_state.active_sa_med_management_tab_v2 = "Manage Medications"; st.rerun()
         else: show_error_message("Failed to add medication.")
@@ -178,7 +178,7 @@ def render_sa_manage_medications_tab(admin_user: dict):
         default_drug_classes = ["Other"] # Fallback if DRUG_CLASSES is empty or not a list
         available_drug_classes_list = DRUG_CLASSES if isinstance(DRUG_CLASSES, list) and DRUG_CLASSES else default_drug_classes
         all_drug_classes_options = ["All"] + sorted(list(set(available_drug_classes_list)))
-        
+
         current_drug_class_filter = st.session_state.get('sa_med_drug_class_filter_v2', "All") # Key updated
         if current_drug_class_filter not in all_drug_classes_options: current_drug_class_filter = "All" # Ensure valid default
         st.session_state.sa_med_drug_class_filter_v2 = st.selectbox("Filter by Drug Class:", options=all_drug_classes_options, index=all_drug_classes_options.index(current_drug_class_filter), key="sa_med_class_filter_dd_v2") # Key updated
@@ -186,29 +186,29 @@ def render_sa_manage_medications_tab(admin_user: dict):
         status_options_map = {"All": None, "Active": True, "Inactive": False}
         current_status_label = st.session_state.get('sa_med_status_filter_label_v2', "All") # Key updated
         st.session_state.sa_med_status_filter_label_v2 = st.radio("Filter by Status:", options=list(status_options_map.keys()), index=list(status_options_map.keys()).index(current_status_label), horizontal=True, key="sa_med_status_radio_v2") # Key updated
-    
+
     if st.button("🔍 Apply Filters / Search", key="sa_apply_med_filters_btn_v2"): st.rerun() # Key updated
 
     meds_data_list = []
-    try: 
+    try:
         active_filter_val = status_options_map[st.session_state.sa_med_status_filter_label_v2] # Key updated
         meds_data_list = MedicationQueries.search_medications(search_term=search_query, drug_class=st.session_state.sa_med_drug_class_filter_v2, is_active=active_filter_val) # Key updated
     except Exception as e: show_error_message(f"Error: {e}")
-    
+
     st.caption(f"Displaying {len(meds_data_list)} medication(s).")
     if not meds_data_list and (search_query or st.session_state.sa_med_drug_class_filter_v2 != "All" or st.session_state.sa_med_status_filter_label_v2 != "All"): # Key updated for filters
         st.info("No medications found matching current filters.")
-    
+
     for med_item_data in meds_data_list:
-        def edit_action_fn(m_data_item=med_item_data): 
+        def edit_action_fn(m_data_item=med_item_data):
             st.session_state.sa_editing_med_id_v2 = m_data_item['id'] # Key updated
             st.session_state.sa_med_form_data_v2 = MedicationQueries.get_medication_details(m_data_item['id']) or m_data_item # Key updated
             st.session_state.active_sa_med_management_tab_v2 = "Add/Edit Medication"; st.rerun() # Key updated
-        
+
         def toggle_status_action_fn(m_id_val=med_item_data['id'], current_active_status=med_item_data.get('is_active', True)):
             handle_sa_toggle_med_status(m_id_val, current_active_status, admin_user['id'])
 
-        card_actions = {"Edit": edit_action_fn, 
+        card_actions = {"Edit": edit_action_fn,
                         f"{'Deactivate' if med_item_data.get('is_active', True) else 'Activate'}": toggle_status_action_fn}
         MedicationCard(medication_data=med_item_data, actions=card_actions, key=f"sa_med_card_{med_item_data['id']}_v2") # Key updated
         st.markdown("---")
@@ -241,21 +241,21 @@ def show_sa_medication_management_page():
     require_role_access([USER_ROLES['SUPER_ADMIN']])
     inject_css()
     st.markdown("<h1>💊 Medication Database Management (Admin)</h1>", unsafe_allow_html=True)
-    
+
     admin = get_current_user()
     if not admin: show_error_message("Admin user data not found."); return
 
     # Initialize session state keys with _v2 suffix
     for key, default_val in [('sa_editing_med_id_v2', None), ('sa_med_form_data_v2', {}),
                              ('sa_med_search_term_v2', ""), ('sa_med_drug_class_filter_v2', "All"),
-                             ('sa_med_status_filter_label_v2', "All"), 
+                             ('sa_med_status_filter_label_v2', "All"),
                              ('active_sa_med_management_tab_v2', "Manage Medications")]:
         if key not in st.session_state: st.session_state[key] = default_val
-    
+
     tab_titles_list = ["Manage Medications", "Add/Edit Medication"]
-    if st.session_state.sa_editing_med_id_v2: 
+    if st.session_state.sa_editing_med_id_v2:
         st.session_state.active_sa_med_management_tab_v2 = tab_titles_list[1]
-    
+
     tabs_obj_list = st.tabs(tab_titles_list)
 
     with tabs_obj_list[0]: render_sa_manage_medications_tab(admin)
@@ -268,10 +268,10 @@ if __name__ == "__main__":
 
     for key, default_val in [('sa_editing_med_id_v2', None), ('sa_med_form_data_v2', {}),
                              ('sa_med_search_term_v2', ""), ('sa_med_drug_class_filter_v2', "All"),
-                             ('sa_med_status_filter_label_v2', "All"), 
+                             ('sa_med_status_filter_label_v2', "All"),
                              ('active_sa_med_management_tab_v2', "Manage Medications")]:
         if key not in st.session_state: st.session_state[key] = default_val
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Med Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Med Mgt.")
 

--- a/pages/18_super_admin_lab_test_management.py
+++ b/pages/18_super_admin_lab_test_management.py
@@ -17,12 +17,12 @@ try:
 except ImportError:
     COMPONENTS_AVAILABLE = False
     # Mock SearchFormComponent
-    class SearchFormComponent: 
+    class SearchFormComponent:
         def __init__(self, search_function=None,result_key_prefix=None,form_key=None,placeholder="Search...",label="Search",session_state_key="default_search_term",auto_submit=False,button_text="Search"):
             self.placeholder, self.label, self.session_state_key = placeholder, label, session_state_key
-        def render(self): 
+        def render(self):
             st.session_state[self.session_state_key] = st.text_input(self.label, value=st.session_state.get(self.session_state_key, ""), placeholder=self.placeholder, key=f"mock_search_sa_lab_mgt_{self.session_state_key}_v2") # Key updated
-            return None 
+            return None
         def get_search_query(self): return st.session_state.get(self.session_state_key, "")
 
     # Define LabTestFormComponent inline as requested if not available
@@ -40,16 +40,16 @@ except ImportError:
                 form_data = {}
                 form_data['name'] = st.text_input("Test Name*", value=self.test_data.get('name', ''), key=f"{self.key_prefix}_name_v2") # Key updated
                 form_data['test_code'] = st.text_input("Test Code (e.g., CPT/LOINC)*", value=self.test_data.get('test_code', ''), key=f"{self.key_prefix}_code_v2") # Key updated
-                
+
                 default_categories = ["Hematology", "Chemistry", "Microbiology", "Endocrinology", "Other"]
                 available_categories = LAB_TEST_CONFIG.get('CATEGORIES', default_categories)
                 if not isinstance(available_categories, list) or not available_categories: available_categories = default_categories
-                
+
                 current_category_idx = 0
                 if self.test_data.get('category') in available_categories:
                     current_category_idx = available_categories.index(self.test_data['category'])
                 form_data['category'] = st.selectbox("Category*", options=available_categories, index=current_category_idx, key=f"{self.key_prefix}_cat_v2") # Key updated
-                
+
                 form_data['sample_type'] = st.text_input("Sample Type (e.g., Blood, Urine, Serum)*", value=self.test_data.get('sample_type', ''), key=f"{self.key_prefix}_sample_v2") # Key updated
                 form_data['normal_range'] = st.text_area("Normal Range", value=self.test_data.get('normal_range', ''), key=f"{self.key_prefix}_range_v2") # Key updated
                 form_data['units'] = st.text_input("Units", value=self.test_data.get('units', ''), key=f"{self.key_prefix}_units_v2") # Key updated
@@ -70,7 +70,7 @@ except ImportError:
             return submitted_data
 
     # Mock LabTestCard
-    def LabTestCard(lab_test_data, actions, key, show_actions=True): 
+    def LabTestCard(lab_test_data, actions, key, show_actions=True):
         status = "Active" if lab_test_data.get('is_active', True) else "Inactive"
         st.markdown(f"**{lab_test_data.get('name', 'N/A')} ({lab_test_data.get('test_code', 'N/A')})** - {status}")
         st.caption(f"Category: {lab_test_data.get('category', 'N/A')} | Sample: {lab_test_data.get('sample_type', 'N/A')}")
@@ -99,7 +99,7 @@ except ImportError:
             if is_active is not None: results = [lt for lt in results if lt.get('is_active') == is_active]
             return sorted(results, key=lambda x: x['name'])
         @staticmethod
-        def get_lab_test_details(lab_test_id): 
+        def get_lab_test_details(lab_test_id):
             return next((copy.deepcopy(lt) for lt in MOCK_LAB_TESTS_DB_SA if lt['id'] == lab_test_id), None)
         @staticmethod
         def create_lab_test(data, created_by_id):
@@ -180,7 +180,7 @@ def render_sa_manage_lab_tests_tab(admin_user: dict):
         cats_list = LAB_TEST_CONFIG.get('CATEGORIES', default_cats)
         if not isinstance(cats_list, list) or not cats_list: cats_list = default_cats
         all_cats_options = ["All"] + sorted(list(set(cats_list)))
-        
+
         current_cat_filter = st.session_state.get('sa_lab_test_category_filter_v2', "All") # Key updated
         if current_cat_filter not in all_cats_options: current_cat_filter = "All"
         st.session_state.sa_lab_test_category_filter_v2 = st.selectbox("Filter by Category:", options=all_cats_options, index=all_cats_options.index(current_cat_filter), key="sa_lab_cat_filter_dd_v2") # Key updated
@@ -188,25 +188,25 @@ def render_sa_manage_lab_tests_tab(admin_user: dict):
         status_options = {"All": None, "Active": True, "Inactive": False}
         current_status_label = st.session_state.get('sa_lab_test_status_filter_label_v2', "All") # Key updated
         st.session_state.sa_lab_test_status_filter_label_v2 = st.radio("Filter by Status:", options=list(status_options.keys()), index=list(status_options.keys()).index(current_status_label), horizontal=True, key="sa_lab_status_radio_v2") # Key updated
-    
+
     if st.button("🔍 Apply Filters / Search", key="sa_apply_lab_filters_btn_v2"): st.rerun() # Key updated
 
     lab_tests_list_data = []
-    try: 
+    try:
         is_active_val = status_options[st.session_state.sa_lab_test_status_filter_label_v2] # Key updated
         lab_tests_list_data = LabTestQueries.search_lab_tests(search_term=search_query, category=st.session_state.sa_lab_test_category_filter_v2, is_active=is_active_val) # Key updated
     except Exception as e: show_error_message(f"Error: {e}")
-    
+
     st.caption(f"Displaying {len(lab_tests_list_data)} lab test(s).")
     if not lab_tests_list_data and (search_query or st.session_state.sa_lab_test_category_filter_v2 != "All" or st.session_state.sa_lab_test_status_filter_label_v2 != "All"): # Keys updated for filters
         st.info("No lab tests found matching current filters.")
-    
+
     for lt_item_data in lab_tests_list_data:
-        def edit_lt_action_fn(lt_data_item=lt_item_data): 
+        def edit_lt_action_fn(lt_data_item=lt_item_data):
             st.session_state.sa_editing_lab_test_id_v2 = lt_data_item['id'] # Key updated
             st.session_state.sa_lab_test_form_data_v2 = LabTestQueries.get_lab_test_details(lt_data_item['id']) or lt_data_item # Key updated
             st.session_state.active_sa_lab_test_management_tab_v2 = "Add/Edit Lab Test"; st.rerun() # Key updated
-        
+
         def toggle_lt_status_action_fn(lt_id_val=lt_item_data['id'], current_active_status=lt_item_data.get('is_active', True)):
             handle_sa_toggle_lab_test_status(lt_id_val, current_active_status, admin_user['id'])
 
@@ -242,21 +242,21 @@ def show_sa_lab_test_management_page():
     require_role_access([USER_ROLES['SUPER_ADMIN']])
     inject_css()
     st.markdown("<h1>🧪 Lab Test Database Management (Admin)</h1>", unsafe_allow_html=True)
-    
+
     admin = get_current_user()
     if not admin: show_error_message("Admin user data not found."); return
 
     # Initialize session state keys with _v2 suffix
     for key, default_val in [('sa_editing_lab_test_id_v2', None), ('sa_lab_test_form_data_v2', {}),
                              ('sa_lab_test_search_term_v2', ""), ('sa_lab_test_category_filter_v2', "All"),
-                             ('sa_lab_test_status_filter_label_v2', "All"), 
+                             ('sa_lab_test_status_filter_label_v2', "All"),
                              ('active_sa_lab_test_management_tab_v2', "Manage Lab Tests")]:
         if key not in st.session_state: st.session_state[key] = default_val
-    
+
     tab_titles_list = ["Manage Lab Tests", "Add/Edit Lab Test"]
     if st.session_state.sa_editing_lab_test_id_v2:  # Key updated
         st.session_state.active_sa_lab_test_management_tab_v2 = tab_titles_list[1] # Key updated
-    
+
     tabs_obj_list = st.tabs(tab_titles_list)
     with tabs_obj_list[0]: render_sa_manage_lab_tests_tab(admin)
     with tabs_obj_list[1]: render_sa_add_edit_lab_test_tab(admin)
@@ -268,10 +268,10 @@ if __name__ == "__main__":
 
     for key, default_val in [('sa_editing_lab_test_id_v2', None), ('sa_lab_test_form_data_v2', {}),
                              ('sa_lab_test_search_term_v2', ""), ('sa_lab_test_category_filter_v2', "All"),
-                             ('sa_lab_test_status_filter_label_v2', "All"), 
+                             ('sa_lab_test_status_filter_label_v2', "All"),
                              ('active_sa_lab_test_management_tab_v2', "Manage Lab Tests")]: # Key updated
         if key not in st.session_state: st.session_state[key] = default_val
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components for SA Lab Test Mgt.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries for SA Lab Test Mgt.")
 

--- a/pages/19_super_admin_system_analytics.py
+++ b/pages/19_super_admin_system_analytics.py
@@ -33,11 +33,11 @@ except ImportError:
         # For example, get_user_registration_summary, get_prescription_creation_summary etc.
 
 try:
-    from database.queries import AnalyticsQueries, DashboardQueries, UserQueries 
-    if not hasattr(UserQueries, 'get_all_users'): 
-        class MockUserQueriesForSA: 
+    from database.queries import AnalyticsQueries, DashboardQueries, UserQueries
+    if not hasattr(UserQueries, 'get_all_users'):
+        class MockUserQueriesForSA:
             @staticmethod
-            def get_all_users(): 
+            def get_all_users():
                 return [
                     {'id': 'user001', 'username': 'doc_john', 'full_name': 'Dr. John Doe', 'role': USER_ROLES['DOCTOR']},
                     {'id': 'user002', 'username': 'asst_jane', 'full_name': 'Jane Assist', 'role': USER_ROLES['ASSISTANT']},
@@ -45,16 +45,16 @@ try:
                 ]
         UserQueries.get_all_users = MockUserQueriesForSA.get_all_users # Patch it if missing
 except ImportError:
-    class UserQueries: 
+    class UserQueries:
             @staticmethod
-            def get_all_users(): 
+            def get_all_users():
                 return [
                     {'id': 'user001', 'username': 'doc_john', 'full_name': 'Dr. John Doe', 'role': USER_ROLES['DOCTOR']},
                     {'id': 'user002', 'username': 'asst_jane', 'full_name': 'Jane Assist', 'role': USER_ROLES['ASSISTANT']},
                     {'id': 'user003', 'username': 'sa_prime', 'full_name': 'Super Admin Prime', 'role': USER_ROLES['SUPER_ADMIN']},
                 ]
 
-    class AnalyticsQueries: 
+    class AnalyticsQueries:
         @staticmethod
         def get_entity_counts():
             # st.warning("AnalyticsQueries (get_entity_counts) not found. Using mock counts.", icon="⚠️")
@@ -77,7 +77,7 @@ except ImportError:
             users = UserQueries.get_all_users() # Use the (potentially patched) UserQueries
             actions = ['login', 'create_patient', 'update_patient', 'create_prescription', 'view_analytics', 'error_occurred']
             entities = ['patient_XYZ', 'prescription_ABC', 'analytics_dash', 'system_log', None]
-            for _ in range(limit * 2): 
+            for _ in range(limit * 2):
                 user = random.choice(users)
                 act = random.choice(actions)
                 activities.append({'timestamp': base_time - timedelta(minutes=random.randint(0, days_back * 1440)),
@@ -90,7 +90,7 @@ except ImportError:
             activities.sort(key=lambda x: x['timestamp'], reverse=True)
             return pd.DataFrame(activities[:limit])
         @staticmethod
-        def get_table_row_counts(): 
+        def get_table_row_counts():
             return {'patients': 1234, 'visits': 6789, 'prescriptions': 3456, 'users': 167, 'medications': 289, 'lab_tests': 123}
     class DashboardQueries: pass
 
@@ -186,10 +186,10 @@ def render_system_health_tab(days_filter):
         h_cols[0].metric("Error Rate (24h)", f"{health.get('error_rate_last_24h', 0):.2f}%")
         h_cols[1].metric("Active Users (24h)", health.get('active_users_last_24h', 'N/A'))
         h_cols[2].metric("Avg. Response (ms)", f"{health.get('avg_response_time_ms', 0)}")
-        
+
         err_timeline = health.get('error_rate_timeline')
         if isinstance(err_timeline, pd.DataFrame) and not err_timeline.empty: TimeSeriesChart(err_timeline, title=f"Error Rate Over Last {days_filter} Days", x='date', y='error_rate_percent')
-        
+
         st.markdown("##### Recent Error Logs (Simulated)"); errors = AnalyticsQueries.get_user_activity(days_back=days_filter, action_type='error_occurred', limit=10)
         if not errors.empty:
             errors_disp = errors.copy(); errors_disp['timestamp'] = errors_disp['timestamp'].apply(lambda x: f"{format_date_display(x)} ({get_time_ago(x)})")
@@ -203,7 +203,7 @@ def render_database_stats_tab():
         db_m = AnalyticsService().get_system_performance_metrics() # Mock includes DB stats
         db_cols = st.columns(3)
         db_cols[0].metric("DB Size", f"{db_m.get('db_size_mb', 0):.2f} MB"); db_cols[1].metric("Total Tables", db_m.get('db_table_count', 'N/A')); db_cols[2].metric("Total Records (Est.)", f"{db_m.get('db_total_records', 0):,}")
-        
+
         st.markdown("##### Table Row Counts (Simulated)"); tbl_counts = AnalyticsQueries.get_table_row_counts()
         if tbl_counts: df_tbls = pd.DataFrame(list(tbl_counts.items()), columns=['Table', 'Rows']); BarChart(df_tbls, title="Rows per Table", x_axis='Table', y_axis='Rows')
         else: st.info("Could not get table counts.")
@@ -216,7 +216,7 @@ def show_system_analytics_page():
 
     top_cols = st.columns([3,1])
     days_filter = top_cols[0].selectbox("Global Time Period:", options=[7,15,30,60,90], format_func=lambda x:f"Last {x}d", index=1, key="sa_analytics_global_days_v2")
-    top_cols[1].markdown("<div>&nbsp;</div>", unsafe_allow_html=True); 
+    top_cols[1].markdown("<div>&nbsp;</div>", unsafe_allow_html=True);
     if top_cols[1].button("🔄 Refresh", key="sa_refresh_all_v2", use_container_width=True): st.rerun()
     st.markdown("---")
 

--- a/pages/2_doctor_todays_patients.py
+++ b/pages/2_doctor_todays_patients.py
@@ -87,7 +87,7 @@ def render_todays_patients_list(doctor: dict):
         for visit_data in upcoming_visits:
             patient_name = format_patient_name(visit_data.get('patient_first_name'), visit_data.get('patient_last_name'))
             visit_time_formatted = format_time_display(visit_data.get('visit_time')) if visit_data.get('visit_time') else "N/A"
-            
+
             # Prepare actions for the PatientCard
             actions = {
                 "View Details": lambda v=visit_data: handle_patient_action("View Details", v),
@@ -105,11 +105,11 @@ def render_todays_patients_list(doctor: dict):
                 'status': visit_data.get('status', 'Scheduled'),
                 # Any other relevant details for the card
             }
-            
+
             try:
                 # Assuming PatientCard is a component that takes this data
                 PatientCard(
-                    patient_data=card_data, 
+                    patient_data=card_data,
                     actions=actions,
                     key=f"patient_card_{visit_data.get('visit_id')}"
                 )
@@ -143,7 +143,7 @@ def render_todays_patients_list(doctor: dict):
             except Exception as e:
                 st.error(f"Could not display patient card for {patient_name}: {e}")
         st.markdown("---")
-    
+
     if other_visits:
         st.subheader("Other Status")
         for visit_data in other_visits:
@@ -154,11 +154,11 @@ def show_todays_patients_page():
     """Main function to display the Today's Patients page."""
     require_authentication()
     require_role_access([USER_ROLES['DOCTOR']]) # Ensure role access
-    
+
     inject_css() # Inject global styles if any specific to this page are added
 
     st.markdown("<h1>📅 Today's Patients</h1>", unsafe_allow_html=True)
-    
+
     doctor = get_current_user()
     if doctor:
         st.info(f"Displaying today's patient list for Dr. {doctor.get('full_name', 'N/A')}.")
@@ -170,15 +170,15 @@ if __name__ == "__main__":
     # Mock session state for isolated testing
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'doc789', 
-            'username': 'dr_today', 
-            'role': USER_ROLES['DOCTOR'], 
+            'id': 'doc789',
+            'username': 'dr_today',
+            'role': USER_ROLES['DOCTOR'],
             'full_name': 'Dr. Every Day',
             'email': 'dr.every@example.com'
         }
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
-    
+
     # show_todays_patients_page() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/3_doctor_prescriptions.py
+++ b/pages/3_doctor_prescriptions.py
@@ -13,9 +13,9 @@ from components.forms import SearchFormComponent, PrescriptionMedicationComponen
 
 # Database Queries
 from database.queries import (
-    PatientQueries, 
-    MedicationQueries, 
-    LabTestQueries, 
+    PatientQueries,
+    MedicationQueries,
+    LabTestQueries,
     PrescriptionQueries
 )
 
@@ -54,7 +54,7 @@ def get_mock_lab_tests(query: str = ""):
     if query:
         return [t for t in tests if query.lower() in t['name'].lower()]
     return tests
-    
+
 def get_mock_prescriptions(query: str, doctor_id: str):
     # Simulate a query that might return prescriptions for a doctor
     # In a real scenario, PrescriptionQueries.search_prescriptions would handle filtering by doctor_id
@@ -63,17 +63,17 @@ def get_mock_prescriptions(query: str, doctor_id: str):
         {'prescription_id': 'rx002', 'patient_name': 'Jane Smith', 'patient_id': 'p002', 'date_issued': '2023-09-15', 'status': 'Expired', 'doctor_id': 'docRxMaster', 'medications': [], 'lab_tests': [{'name': 'Lipid Panel'}]},
         {'prescription_id': 'rx003', 'patient_name': 'John Doe', 'patient_id': 'p001', 'date_issued': '2023-08-20', 'status': 'Completed', 'doctor_id': 'anotherDoc', 'medications': [{'name': 'Paracetamol 500mg'}], 'lab_tests': []},
     ]
-    
+
     # Filter by doctor_id first
     doctor_prescriptions = [rx for rx in all_prescriptions if rx['doctor_id'] == doctor_id]
 
     if not query: # If no specific query, return all for the doctor
         return doctor_prescriptions
-        
+
     # Simple text search in patient_name or prescription_id
     query_lower = query.lower()
     return [
-        rx for rx in doctor_prescriptions 
+        rx for rx in doctor_prescriptions
         if query_lower in rx['patient_name'].lower() or query_lower in rx['prescription_id'].lower()
     ]
 
@@ -131,7 +131,7 @@ def render_create_prescription_tab(doctor: dict):
 
     # 1. Patient Selection
     st.markdown("#### 1. Select Patient")
-    
+
     try:
         patient_search_fn = PatientQueries.search_patients
     except AttributeError:
@@ -145,7 +145,7 @@ def render_create_prescription_tab(doctor: dict):
         placeholder="Search patient by name or ID...",
         label="Find Patient"
     )
-    selected_patient_id = patient_search_form.render() 
+    selected_patient_id = patient_search_form.render()
 
     if selected_patient_id and (not st.session_state.get('selected_patient_for_rx') or st.session_state.selected_patient_for_rx['id'] != selected_patient_id) :
         try:
@@ -171,12 +171,12 @@ def render_create_prescription_tab(doctor: dict):
         patient = st.session_state.selected_patient_for_rx
         patient_name = format_patient_name(patient['first_name'], patient['last_name'])
         st.success(f"Selected Patient: **{patient_name}** (ID: {patient['id']})")
-        
+
         with st.expander("Patient Details", expanded=False):
             st.write(f"**DOB:** {patient.get('dob', 'N/A')}, **Gender:** {patient.get('gender', 'N/A')}")
             st.write(f"**Allergies:** {', '.join(patient.get('allergies', [])) if patient.get('allergies') else 'None reported'}")
             st.write(f"**Existing Conditions:** {', '.join(patient.get('conditions', [])) if patient.get('conditions') else 'None reported'}")
-        
+
         if st.button("Clear Selected Patient", key="clear_patient_btn"):
             st.session_state.selected_patient_for_rx = None
             st.session_state.rx_medications = []
@@ -188,13 +188,13 @@ def render_create_prescription_tab(doctor: dict):
         with st.form("create_prescription_form"):
             chief_complaint = st.text_input("Chief Complaint / Reason for Visit", key="rx_chief_complaint")
             diagnosis = st.text_area("Diagnosis / Clinical Impression", key="rx_diagnosis")
-            
+
             st.markdown("##### Medications")
             try:
                 available_meds = MedicationQueries.search_medications("")
             except AttributeError:
                 available_meds = get_mock_medications()
-            
+
             med_component = PrescriptionMedicationComponent(
                 current_medications=st.session_state.get('rx_medications', []),
                 available_medications=available_meds,
@@ -214,9 +214,9 @@ def render_create_prescription_tab(doctor: dict):
                 key_prefix="rx_lab"
             )
             st.session_state.rx_lab_tests = test_component.render()
-            
+
             general_notes = st.text_area("General Notes / Advice to Patient", key="rx_general_notes")
-            
+
             # AI Analysis Button (Placeholder) - Placed outside main submit logic if it's not a primary action
             # This button is tricky inside st.form if it's not THE submit button.
             # For now, it will also act as a submit button for the form.
@@ -244,7 +244,7 @@ def render_create_prescription_tab(doctor: dict):
                         "general_notes": general_notes,
                     }
                     if handle_save_prescription(prescription_data, st.session_state.rx_medications, st.session_state.rx_lab_tests, doctor):
-                        st.rerun() 
+                        st.rerun()
     else:
         st.info("Please search and select a patient to begin creating a prescription.")
 
@@ -257,11 +257,11 @@ def render_view_prescriptions_tab(doctor: dict):
     except AttributeError:
         st.warning("Prescription search system initializing. Using mock prescription data.", icon="⚠️")
         prescription_search_fn = lambda query: get_mock_prescriptions(query, doctor['id'])
-        
+
     # We need a way to trigger the search. A button or on query change.
     # For simplicity, use a text input and a button.
     search_query_prescriptions = st.text_input("Search by Patient Name, Rx ID...", key="rx_search_query_input")
-    
+
     if st.button("Search Prescriptions", key="rx_search_btn") or search_query_prescriptions:
         try:
             prescriptions = prescription_search_fn(search_query_prescriptions)
@@ -282,13 +282,13 @@ def render_view_prescriptions_tab(doctor: dict):
                 try:
                     # Ensure PrescriptionCard is robust enough or provide default values
                     PrescriptionCard(
-                        prescription_data=rx, 
-                        actions=actions, 
+                        prescription_data=rx,
+                        actions=actions,
                         key=f"rx_card_{rx.get('prescription_id', rx_idx)}" # Ensure unique key
                     )
                 except Exception as e:
                     st.error(f"Error rendering prescription card for {rx.get('prescription_id')}: {e}")
-                    st.json(rx) 
+                    st.json(rx)
     else:
         st.info("Enter search terms above and click 'Search Prescriptions' to find existing prescriptions for your patients.")
 
@@ -297,12 +297,12 @@ def render_view_prescriptions_tab(doctor: dict):
 def show_prescriptions_page():
     require_authentication()
     require_role_access([USER_ROLES['DOCTOR']])
-    
+
     # inject_prescription_css() # If specific CSS for this page exists
     inject_css() # Global CSS
 
     st.markdown("<h1>📝 Prescription Management</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if not current_user:
         show_error_message("Unable to retrieve user information. Please log in again.")
@@ -321,7 +321,7 @@ def show_prescriptions_page():
 
     with tab1:
         render_create_prescription_tab(current_user)
-    
+
     with tab2:
         render_view_prescriptions_tab(current_user)
 
@@ -329,9 +329,9 @@ if __name__ == "__main__":
     # Mock session state for isolated testing
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'docRxMaster', 
-            'username': 'dr_prescriber', 
-            'role': USER_ROLES['DOCTOR'], 
+            'id': 'docRxMaster',
+            'username': 'dr_prescriber',
+            'role': USER_ROLES['DOCTOR'],
             'full_name': 'Dr. Rx Master',
             'email': 'dr.rx@example.com'
         }
@@ -344,7 +344,7 @@ if __name__ == "__main__":
         st.session_state.rx_medications = []
     if 'rx_lab_tests' not in st.session_state:
         st.session_state.rx_lab_tests = []
-    
+
     # show_prescriptions_page() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/4_doctor_templates.py
+++ b/pages/4_doctor_templates.py
@@ -26,16 +26,16 @@ def initialize_mock_db():
     if not MOCK_TEMPLATES_DB: # Only add if empty, to prevent duplicates on reruns in dev
         mock_create_template({
             "name": "Standard Flu Follow-up", "category": "Follow-up",
-            "description": "Template for typical flu follow-up.", 
+            "description": "Template for typical flu follow-up.",
             "diagnosis": "Seasonal Influenza", "instructions": "Rest, hydrate, monitor fever.",
-            "medications": [{"name": "Oseltamivir", "dosage": "75mg", "frequency": "BID", "duration": "5 days"}], 
+            "medications": [{"name": "Oseltamivir", "dosage": "75mg", "frequency": "BID", "duration": "5 days"}],
             "lab_tests": []
         }, 'docTemplateUser', is_initial_setup=True)
         mock_create_template({
             "name": "Routine Checkup", "category": "General",
-            "description": "Baseline health check.", 
+            "description": "Baseline health check.",
             "diagnosis": "Routine Health Maintenance", "instructions": "Discuss lifestyle, schedule next visit.",
-            "medications": [], 
+            "medications": [],
             "lab_tests": [{"name": "Lipid Panel", "instructions": "Fasting required"}]
         }, 'docTemplateUser', is_initial_setup=True)
 
@@ -53,7 +53,7 @@ def mock_create_template(data, doctor_id, is_initial_setup=False):
     # is_initial_setup flag to prevent success messages during __main__ setup
     new_id = f"tmpl_{len(MOCK_TEMPLATES_DB) + 1}_{datetime.now().strftime('%S%f')}" # more unique ID
     new_template = {
-        'id': new_id, 'doctor_id': doctor_id, **data, 
+        'id': new_id, 'doctor_id': doctor_id, **data,
         'created_at': datetime.now().isoformat(), 'updated_at': datetime.now().isoformat()
     }
     MOCK_TEMPLATES_DB.append(new_template)
@@ -124,7 +124,7 @@ def handle_delete_template(template_id, doctor_id):
         except Exception as e:
             show_error_message(f"Error deleting template: {e}")
             success = False
-        
+
         del st.session_state[f"confirm_delete_{template_id}"]
         if success: st.rerun()
     else:
@@ -149,7 +149,7 @@ def process_duplication(original_template_id, new_name, doctor_id):
 
         duplicated_data = {k: v for k, v in original_template.items() if k not in ['id', 'created_at', 'updated_at', 'doctor_id']}
         duplicated_data['name'] = new_name
-            
+
         # new_template = TemplateService.create_template(duplicated_data, doctor_id) # Actual
         new_template = mock_create_template(duplicated_data, doctor_id) # Mock
         if new_template:
@@ -173,7 +173,7 @@ def render_view_templates_section(doctor: dict):
         # original_template = TemplateQueries.get_template_details(original_template_id, doctor['id']) # Actual
         original_template = get_mock_template_by_id(original_template_id, doctor['id']) # Mock
         default_new_name = f"{original_template['name']} (Copy)" if original_template else "New Template Name"
-        
+
         st.text_input("Enter name for duplicated template:", value=default_new_name, key="new_template_name_for_duplicate")
         col1, col2 = st.columns(2)
         if col1.button("✅ Confirm Duplicate", key="confirm_duplicate_btn"):
@@ -192,7 +192,7 @@ def render_view_templates_section(doctor: dict):
         }
         st.rerun()
     st.markdown("---")
-    
+
     try:
         templates = TemplateQueries.get_doctor_templates(doctor['id']) # Actual
     except AttributeError:
@@ -227,7 +227,7 @@ def render_view_templates_section(doctor: dict):
 
 def edit_template_action(template_data):
     st.session_state.editing_template_id = template_data['id']
-    st.session_state.template_form_data = copy.deepcopy(template_data) 
+    st.session_state.template_form_data = copy.deepcopy(template_data)
     if 'medications' not in st.session_state.template_form_data or st.session_state.template_form_data['medications'] is None:
         st.session_state.template_form_data['medications'] = []
     if 'lab_tests' not in st.session_state.template_form_data or st.session_state.template_form_data['lab_tests'] is None:
@@ -237,23 +237,23 @@ def edit_template_action(template_data):
 def render_edit_template_section(doctor: dict):
     form_data = st.session_state.template_form_data
     is_new_template = st.session_state.editing_template_id == 'new'
-    
+
     header = "Create New Template" if is_new_template else f"Edit Template: {form_data.get('name', '')}"
     st.subheader(header)
 
     with st.form("template_form"):
         current_name = form_data.get('name', '')
         form_data['name'] = st.text_input("Template Name", value=current_name)
-        
+
         # Ensure category list is not empty and selection is valid
         categories = TEMPLATE_CONFIG.get('CATEGORIES', ["General", "Follow-up"])
         current_category = form_data.get('category', categories[0])
         if current_category not in categories: current_category = categories[0]
         category_index = categories.index(current_category)
         form_data['category'] = st.selectbox("Category", options=categories, index=category_index)
-        
+
         form_data['description'] = st.text_area("Description (optional)", value=form_data.get('description', ''))
-        
+
         st.markdown("##### Content")
         form_data['diagnosis'] = st.text_area("Diagnosis / Clinical Impression", value=form_data.get('diagnosis', ''))
         form_data['instructions'] = st.text_area("General Instructions / Advice", value=form_data.get('instructions', ''))
@@ -264,7 +264,7 @@ def render_edit_template_section(doctor: dict):
             form_data['medications'], num_rows="dynamic", key="med_editor",
             column_config={ "name": st.column_config.TextColumn("Medication Name", required=True), "dosage": "Dosage", "frequency": "Frequency", "duration": "Duration"}
         )
-        
+
         st.markdown("##### Lab Tests")
         if 'lab_tests' not in form_data or not isinstance(form_data['lab_tests'], list): form_data['lab_tests'] = []
         form_data['lab_tests'] = st.data_editor(
@@ -288,9 +288,9 @@ def render_edit_template_section(doctor: dict):
                 st.session_state.editing_template_id = None
                 st.session_state.template_form_data = {}
                 st.rerun()
-    
+
     # This direct update to session state outside form submission might be problematic if st.rerun is called elsewhere
-    # st.session_state.template_form_data = form_data 
+    # st.session_state.template_form_data = form_data
 
 
 # --- Main Page Function ---
@@ -300,7 +300,7 @@ def show_templates_page():
     inject_css()
 
     st.markdown("<h1>📋 Prescription Templates</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if not current_user:
         show_error_message("Unable to retrieve user information. Please log in again.")
@@ -319,7 +319,7 @@ def show_templates_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'docTemplateUser', 'username': 'dr_templater', 
+            'id': 'docTemplateUser', 'username': 'dr_templater',
             'role': USER_ROLES['DOCTOR'], 'full_name': 'Dr. Templater',
             'email': 'dr.templater@example.com'
         }
@@ -329,7 +329,7 @@ if __name__ == "__main__":
     if 'editing_template_id' not in st.session_state: st.session_state.editing_template_id = None
     if 'template_form_data' not in st.session_state: st.session_state.template_form_data = {}
     if 'duplicating_template_id' not in st.session_state: st.session_state.duplicating_template_id = None
-    
+
     initialize_mock_db() # Populate mock DB for testing
     # show_templates_page() # Called at module level now
 

--- a/pages/5_doctor_medications.py
+++ b/pages/5_doctor_medications.py
@@ -36,29 +36,29 @@ def get_mock_medications(search_term: str, drug_class: str, favorites_only: bool
     if search_term:
         search_term_lower = search_term.lower()
         results = [
-            m for m in results if 
-            search_term_lower in m['name'].lower() or 
+            m for m in results if
+            search_term_lower in m['name'].lower() or
             search_term_lower in m.get('generic_name','').lower()
         ]
-    
+
     if drug_class != "All": # Assuming "All" means no filter by drug class
         results = [m for m in results if m.get('drug_class') == drug_class]
 
     # Add 'is_favorite' status before filtering by favorites_only
     for med in results:
         med['is_favorite'] = med['id'] in doctor_favorites
-        
+
     if favorites_only:
         results = [m for m in results if m['is_favorite']]
-        
+
     return results
 
 def mock_toggle_favorite_medication(medication_id: str, doctor_id: str):
     if doctor_id not in MOCK_FAVORITE_MEDS:
         MOCK_FAVORITE_MEDS[doctor_id] = set()
-    
+
     is_currently_favorite = medication_id in MOCK_FAVORITE_MEDS[doctor_id]
-    
+
     if is_currently_favorite:
         MOCK_FAVORITE_MEDS[doctor_id].remove(medication_id)
         return False # Was favorite, now not
@@ -71,7 +71,7 @@ def handle_toggle_favorite(medication_id: str, doctor_id: str, is_currently_favo
     try:
         # success = MedicationQueries.toggle_favorite_medication(medication_id, doctor_id, not is_currently_favorite) # Actual
         # The mock function itself toggles, so we just call it.
-        new_fav_status = mock_toggle_favorite_medication(medication_id, doctor_id) 
+        new_fav_status = mock_toggle_favorite_medication(medication_id, doctor_id)
         action = "added to" if new_fav_status else "removed from"
         show_success_message(f"Medication {action} favorites.")
     except AttributeError:
@@ -81,20 +81,20 @@ def handle_toggle_favorite(medication_id: str, doctor_id: str, is_currently_favo
         show_success_message(f"Medication {action} favorites (mock).")
     except Exception as e:
         show_error_message(f"Error updating favorite status: {e}")
-    
+
     st.rerun() # Rerun to reflect changes immediately
 
 
 # --- UI Rendering Functions ---
 def render_medication_search_and_filters():
     st.subheader("🔍 Search & Filter Medications")
-    
+
     # For SearchFormComponent, it would typically manage its own state and return search term
     # For simplicity here, using st.text_input directly with session_state
     st.session_state.med_search_term = st.text_input(
-        "Search by Name or Generic Name:", 
+        "Search by Name or Generic Name:",
         value=st.session_state.get('med_search_term', ""),
-        key="med_search_input_main" 
+        key="med_search_input_main"
     )
 
     # Filters in columns
@@ -103,22 +103,22 @@ def render_medication_search_and_filters():
         # Ensure DRUG_CLASSES is a list, provide a default if not.
         available_drug_classes = DRUG_CLASSES if isinstance(DRUG_CLASSES, list) else ["Analgesics", "Antibiotics", "NSAIDs", "ACE Inhibitors", "Bronchodilators", "Biguanides", "Penicillin Antibiotics"]
         all_drug_classes_options = ["All"] + sorted(list(set(available_drug_classes))) # Ensure unique and sorted
-        
+
         current_drug_class = st.session_state.get('med_drug_class', "All")
         if current_drug_class not in all_drug_classes_options: # Handle case where saved class is no longer valid
             current_drug_class_index = 0 # Default to "All"
         else:
             current_drug_class_index = all_drug_classes_options.index(current_drug_class)
-        
+
         st.session_state.med_drug_class = st.selectbox(
-            "Filter by Drug Class:", 
-            options=all_drug_classes_options, 
+            "Filter by Drug Class:",
+            options=all_drug_classes_options,
             index=current_drug_class_index,
             key="med_drug_class_filter_main"
         )
     with filter_cols[1]:
         st.session_state.med_show_favorites = st.checkbox(
-            "Show Only My Favorites ⭐", 
+            "Show Only My Favorites ⭐",
             value=st.session_state.get('med_show_favorites', False),
             key="med_favorites_filter_main"
         )
@@ -144,10 +144,10 @@ def render_medications_list():
 
     try:
         # medications_list = MedicationQueries.search_medications(
-        #     search_term=search_term, 
+        #     search_term=search_term,
         #     drug_class=drug_class_filter if drug_class_filter != "All" else None,
         #     favorites_only=favorites_only_filter,
-        #     doctor_id=doctor['id'] 
+        #     doctor_id=doctor['id']
         # ) # Actual
         medications_list = get_mock_medications(search_term, drug_class_filter, favorites_only_filter, doctor['id']) # Mock
     except AttributeError:
@@ -161,13 +161,13 @@ def render_medications_list():
         st.info("No medications found matching your criteria. Try adjusting your search or filters.")
         return
 
-    num_columns = 3 
+    num_columns = 3
     item_cols = st.columns(num_columns)
     for i, med_item_data in enumerate(medications_list):
         with item_cols[i % num_columns]:
             is_fav = med_item_data.get('is_favorite', False)
             fav_button_label = "🌟 Unfavorite" if is_fav else "⭐ Favorite"
-            
+
             # Define actions for the card
             card_actions = {
                 fav_button_label: lambda m_id=med_item_data['id'], d_id=doctor['id'], current_fav_status=is_fav: handle_toggle_favorite(m_id, d_id, current_fav_status),
@@ -187,7 +187,7 @@ def show_medications_page():
     inject_css()
 
     st.markdown("<h1>💊 Medications Database</h1>", unsafe_allow_html=True)
-    
+
     if 'med_search_term' not in st.session_state: st.session_state.med_search_term = ""
     if 'med_drug_class' not in st.session_state: st.session_state.med_drug_class = "All"
     if 'med_show_favorites' not in st.session_state: st.session_state.med_show_favorites = False
@@ -198,7 +198,7 @@ def show_medications_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'docMedBrowser', 'username': 'dr_medsearch', 
+            'id': 'docMedBrowser', 'username': 'dr_medsearch',
             'role': USER_ROLES['DOCTOR'], 'full_name': 'Dr. Med Browser',
             'email': 'dr.meds@example.com'
         }
@@ -215,7 +215,7 @@ if __name__ == "__main__":
         MOCK_FAVORITE_MEDS['docMedBrowser'] = set() # Ensure the set exists
         mock_toggle_favorite_medication('med001', 'docMedBrowser') # Amoxicillin
         mock_toggle_favorite_medication('med003', 'docMedBrowser') # Lisinopril
-    
+
     # show_medications_page() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/6_doctor_lab_tests.py
+++ b/pages/6_doctor_lab_tests.py
@@ -29,27 +29,27 @@ MOCK_LAB_TESTS_DB = [
 ]
 
 def get_mock_lab_tests(search_term: str, category: str):
-    results = copy.deepcopy(MOCK_LAB_TESTS_DB) 
+    results = copy.deepcopy(MOCK_LAB_TESTS_DB)
 
     if search_term:
         search_term_lower = search_term.lower()
         results = [
-            lt for lt in results if 
+            lt for lt in results if
             search_term_lower in lt['name'].lower() or
             search_term_lower in lt.get('description', '').lower()
         ]
-    
-    if category != "All": 
+
+    if category != "All":
         results = [lt for lt in results if lt.get('category') == category]
-        
+
     return results
 
 # --- UI Rendering Functions ---
 def render_lab_test_search_and_filters():
     st.subheader("🔍 Search & Filter Lab Tests")
-    
+
     st.session_state.lab_search_term = st.text_input(
-        "Search by Name or Description:", 
+        "Search by Name or Description:",
         value=st.session_state.get('lab_search_term', ""),
         key="lab_search_input_main_v2" # Changed key to avoid conflict if old one is stuck
     )
@@ -63,23 +63,23 @@ def render_lab_test_search_and_filters():
             available_categories = default_categories
         else:
             available_categories = config_categories
-            
-        all_category_options = ["All"] + sorted(list(set(available_categories))) 
-        
+
+        all_category_options = ["All"] + sorted(list(set(available_categories)))
+
         current_category = st.session_state.get('lab_test_category', "All")
-        if current_category not in all_category_options: 
-            current_category_index = 0 
+        if current_category not in all_category_options:
+            current_category_index = 0
         else:
             current_category_index = all_category_options.index(current_category)
-        
+
         st.session_state.lab_test_category = st.selectbox(
-            "Filter by Test Category:", 
-            options=all_category_options, 
+            "Filter by Test Category:",
+            options=all_category_options,
             index=current_category_index,
             key="lab_category_filter_main_v2" # Changed key
         )
     with filter_cols[1]:
-        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) 
+        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True)
         if st.button("🔄 Refresh / Apply", key="lab_refresh_btn_main_v2", use_container_width=True): # Changed key
             st.rerun()
 
@@ -88,13 +88,13 @@ def render_lab_test_search_and_filters():
 
 def render_lab_tests_list():
     st.subheader("Lab Test Listings")
-    
+
     search_term = st.session_state.get('lab_search_term', "")
     category_filter = st.session_state.get('lab_test_category', "All")
 
     try:
         # lab_tests_list_data = LabTestQueries.search_lab_tests(
-        #     search_term=search_term, 
+        #     search_term=search_term,
         #     category=category_filter if category_filter != "All" else None,
         # ) # Actual
         lab_tests_list_data = get_mock_lab_tests(search_term, category_filter) # Mock
@@ -109,7 +109,7 @@ def render_lab_tests_list():
         st.info("No lab tests found matching your criteria. Try adjusting your search or filters.")
         return
 
-    num_columns = 3 
+    num_columns = 3
     item_cols = st.columns(num_columns)
     for i, test_item_data_obj in enumerate(lab_tests_list_data):
         with item_cols[i % num_columns]:
@@ -130,7 +130,7 @@ def show_lab_tests_page():
     inject_css()
 
     st.markdown("<h1>🧪 Lab Tests Database</h1>", unsafe_allow_html=True)
-    
+
     if 'lab_search_term' not in st.session_state: st.session_state.lab_search_term = ""
     if 'lab_test_category' not in st.session_state: st.session_state.lab_test_category = "All"
 
@@ -140,9 +140,9 @@ def show_lab_tests_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'docLabBrowser', 
-            'username': 'dr_labsearch', 
-            'role': USER_ROLES['DOCTOR'], 
+            'id': 'docLabBrowser',
+            'username': 'dr_labsearch',
+            'role': USER_ROLES['DOCTOR'],
             'full_name': 'Dr. Lab Browser',
             'email': 'dr.labs@example.com'
         }
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
     if 'lab_search_term' not in st.session_state: st.session_state.lab_search_term = ""
     if 'lab_test_category' not in st.session_state: st.session_state.lab_test_category = "All"
-    
+
     # show_lab_tests_page() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/7_doctor_analytics.py
+++ b/pages/7_doctor_analytics.py
@@ -30,7 +30,7 @@ except ImportError:
         def get_patient_analytics(self, role, user_id, days_back): # For patients this doctor interacted with
             st.warning("AnalyticsService not found. Using mock patient analytics.")
             return {
-                'patient_demographics': pd.DataFrame({ 
+                'patient_demographics': pd.DataFrame({
                     'age_group': ['0-18', '19-35', '36-50', '51-65', '65+'],
                     'count': [max(0, int(days_back/10 + i*2 - (i%2)*5)) for i in range(5)] # Data varies with days_back
                 }),
@@ -38,9 +38,9 @@ except ImportError:
                     'gender': ['Male', 'Female', 'Other', 'Prefer not to say'],
                     'count': [max(0,int(days_back/5 + i*3)) for i in range(4)]
                 }),
-                'new_vs_returning_patients': {'new': max(0,int(days_back/3)), 'returning': max(0,int(days_back*2/3))} 
+                'new_vs_returning_patients': {'new': max(0,int(days_back/3)), 'returning': max(0,int(days_back*2/3))}
             }
-        def get_medication_analytics(self, role, user_id, days_back): 
+        def get_medication_analytics(self, role, user_id, days_back):
             st.warning("AnalyticsService not found. Using mock medication analytics.")
             med_names = ['Amoxicillin', 'Lisinopril', 'Metformin', 'Paracetamol', 'Salbutamol', 'Aspirin', 'Omeprazole']
             return {
@@ -56,10 +56,10 @@ except ImportError:
 
 try:
     from components.charts import (
-        PrescriptionTrendChart, 
-        PatientDemographicsChart, 
+        PrescriptionTrendChart,
+        PatientDemographicsChart,
         MedicationUsageChart,
-        AnalyticsDashboard 
+        AnalyticsDashboard
     )
     # If AnalyticsDashboard exists, we might prefer it.
     # For this example, we'll assume individual charts are primary.
@@ -84,8 +84,8 @@ except ImportError:
     PrescriptionTrendChart = create_mock_chart_component("Prescription Trend Chart")
     PatientDemographicsChart = create_mock_chart_component("Patient Demographics Chart")
     MedicationUsageChart = create_mock_chart_component("Medication Usage Chart")
-    
-    class AnalyticsDashboard: 
+
+    class AnalyticsDashboard:
         def __init__(self, data=None, title=None):
             self.data = data
             self.title = title
@@ -114,10 +114,10 @@ def render_analytics_content(doctor: dict):
             index=1 # Default to 30 days
         )
     with col2:
-        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) 
+        st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True)
         if st.button("🔄 Refresh Data", key="refresh_analytics_main", use_container_width=True):
             st.rerun()
-    
+
     st.markdown("---")
 
     try:
@@ -131,16 +131,16 @@ def render_analytics_content(doctor: dict):
 
     # --- Display Charts ---
     # Using individual charts for now.
-    
+
     st.header("Prescription Analytics")
     if prescription_analytics:
         total_rx = prescription_analytics.get('total_prescriptions', 0)
         avg_meds = prescription_analytics.get('average_meds_per_prescription', 0.0)
-        
+
         kpi_cols_rx = st.columns(2)
         kpi_cols_rx[0].metric(label="Total Prescriptions Issued", value=total_rx if total_rx is not None else "N/A")
         kpi_cols_rx[1].metric(label="Avg. Meds per Prescription", value=f"{avg_meds:.1f}" if isinstance(avg_meds, (int,float)) else "N/A")
-        
+
         timeline_data = prescription_analytics.get('prescriptions_timeline')
         if timeline_data is not None and not timeline_data.empty:
             PrescriptionTrendChart(timeline_data, title=f"Prescription Volume (Last {selected_period_days} Days)")
@@ -148,7 +148,7 @@ def render_analytics_content(doctor: dict):
             st.info("No prescription timeline data available.")
     else:
         st.info("No prescription analytics data available for the selected period.")
-    
+
     st.markdown("---")
     st.header("Medication Analytics")
     if medication_analytics:
@@ -201,7 +201,7 @@ def show_doctor_analytics_page():
     inject_css()
 
     st.markdown("<h1>📊 My Analytics Dashboard</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if not current_user:
         show_error_message("Unable to retrieve user information. Please log in again.")
@@ -212,15 +212,15 @@ def show_doctor_analytics_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'docAnalyticsUser', 
-            'username': 'dr_stats', 
-            'role': USER_ROLES['DOCTOR'], 
+            'id': 'docAnalyticsUser',
+            'username': 'dr_stats',
+            'role': USER_ROLES['DOCTOR'],
             'full_name': 'Dr. Stats',
             'email': 'dr.stats@example.com'
         }
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
-    
+
     # show_doctor_analytics_page() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/8_assistant_dashboard.py
+++ b/pages/8_assistant_dashboard.py
@@ -65,12 +65,12 @@ except ImportError:
             start_date = datetime.now() - timedelta(days=days_back)
             filtered = [v for v in filtered if datetime.fromisoformat(v['visit_date']) >= start_date]
             return len(filtered)
-        
+
         @staticmethod
         def get_all_today_visits(): # All visits scheduled for today, regardless of who recorded
             today_str = datetime.now().date().isoformat()
             return len([v for v in MOCK_ASSISTANT_VISITS_DB if v['visit_date'].startswith(today_str)])
-    
+
     class DashboardQueries: pass # Placeholder
 
 # Utils
@@ -94,15 +94,15 @@ def render_assistant_dashboard_content(current_user: dict):
         st.markdown("<div>&nbsp;</div>", unsafe_allow_html=True) # Spacer for better alignment
         if st.button("🔄 Refresh Data", key="refresh_assistant_dash_main", use_container_width=True):
             st.rerun()
-    
+
     st.markdown("---")
 
     # --- Key Metrics ---
     st.markdown("<h4>Key Metrics</h4>", unsafe_allow_html=True)
-    
+
     patients_registered_by_me = 0
     visits_recorded_by_me = 0
-    
+
     try: # Try AnalyticsService first
         analytics_service = AnalyticsService()
         assistant_metrics = analytics_service.get_dashboard_metrics(
@@ -131,9 +131,9 @@ def render_assistant_dashboard_content(current_user: dict):
     m_cols[1].metric(label=f"Visits Recorded (Last {days_back_filter}d)", value=visits_recorded_by_me)
     m_cols[2].metric(label="Total Patients You Manage", value=total_patients_managed)
     m_cols[3].metric(label="Upcoming Appointments Today (All)", value=upcoming_appointments_today)
-    
+
     st.markdown("---")
-    
+
     # --- Quick Actions ---
     st.subheader("🚀 Quick Actions")
     qa_cols = st.columns(2)
@@ -143,7 +143,7 @@ def render_assistant_dashboard_content(current_user: dict):
     if qa_cols[1].button("➕ Record New Visit", use_container_width=True, type="primary"):
         st.toast("Action: Navigate to Record Visit (Simulated).")
         # Replace with: st.switch_page("pages/assistant/record_visit.py") when available
-            
+
     st.markdown("---")
     st.info("Recent activity and task list sections will be available soon.")
 
@@ -151,13 +151,13 @@ def render_assistant_dashboard_content(current_user: dict):
 # --- Main Page Function ---
 def show_assistant_dashboard():
     require_authentication()
-    require_role_access([USER_ROLES['ASSISTANT']]) 
-    
-    inject_css() 
-    # inject_component_css('DASHBOARD_CARDS') 
+    require_role_access([USER_ROLES['ASSISTANT']])
+
+    inject_css()
+    # inject_component_css('DASHBOARD_CARDS')
 
     st.markdown("<h1>💁‍♀️ Assistant Dashboard</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if current_user:
         st.sidebar.success(f"Welcome, {current_user.get('full_name', 'Assistant')}!")
@@ -169,15 +169,15 @@ def show_assistant_dashboard():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'assistant123', 
-            'username': 'med_assistant_jane', 
-            'role': USER_ROLES['ASSISTANT'], 
+            'id': 'assistant123',
+            'username': 'med_assistant_jane',
+            'role': USER_ROLES['ASSISTANT'],
             'full_name': 'Jane Doe (Assistant)',
             'email': 'jane.assistant@example.com'
         }
         st.session_state.authenticated = True
         st.session_state.session_valid_until = datetime.now() + timedelta(hours=1)
-    
+
     # show_assistant_dashboard() # Called at module level now
 
 # This call ensures Streamlit runs the page content when navigating

--- a/pages/9_assistant_patient_management.py
+++ b/pages/9_assistant_patient_management.py
@@ -17,19 +17,19 @@ except ImportError:
     # Mock SearchFormComponent
     class SearchFormComponent:
         def __init__(self, search_function=None, result_key_prefix=None, form_key=None, placeholder="Search...", label="Search", session_state_key="default_search_term", auto_submit=False, button_text="Search"):
-            self.search_function = search_function 
+            self.search_function = search_function
             self.placeholder = placeholder
             self.label = label
             self.session_state_key = session_state_key
             self.auto_submit = auto_submit # Not used in this simple mock
             self.button_text = button_text # Not used in this simple mock
 
-        def render(self): 
-            st.session_state[self.session_state_key] = st.text_input(self.label, 
-                                                                    value=st.session_state.get(self.session_state_key, ""), 
+        def render(self):
+            st.session_state[self.session_state_key] = st.text_input(self.label,
+                                                                    value=st.session_state.get(self.session_state_key, ""),
                                                                     placeholder=self.placeholder,
                                                                     key=f"mock_search_ssf_{self.session_state_key}")
-            return None 
+            return None
         def get_search_query(self):
              return st.session_state.get(self.session_state_key, "")
 
@@ -49,7 +49,7 @@ except ImportError:
                 form_data = {}
                 form_data['first_name'] = st.text_input("First Name*", value=self.patient_data.get('first_name', ''), key=f"{self.key_prefix}_fname_main")
                 form_data['last_name'] = st.text_input("Last Name*", value=self.patient_data.get('last_name', ''), key=f"{self.key_prefix}_lname_main")
-                
+
                 dob_val = self.patient_data.get('dob')
                 if isinstance(dob_val, str):
                     try: dob_val = datetime.strptime(dob_val, '%Y-%m-%d').date()
@@ -66,7 +66,7 @@ except ImportError:
                 form_data['allergies'] = st.text_area("Allergies", value=self.patient_data.get('allergies', ''), key=f"{self.key_prefix}_allergies_main")
                 form_data['medical_history'] = st.text_area("Medical History Summary", value=self.patient_data.get('medical_history', ''), key=f"{self.key_prefix}_medhist_main")
 
-                
+
                 submit_btn_label = "Update Patient" if self.edit_mode else "Register Patient"
                 col1, col2 = st.columns([3,1])
                 with col1:
@@ -87,7 +87,7 @@ except ImportError:
 try:
     from components.cards import PatientCard
 except ImportError:
-    def PatientCard(patient_data, actions, key): 
+    def PatientCard(patient_data, actions, key):
         st.markdown(f"**{patient_data.get('first_name', 'N/A')} {patient_data.get('last_name', 'N/A')}** (ID: {patient_data.get('id', 'N/A')})")
         st.caption(f"DOB: {patient_data.get('dob', 'N/A')}, Phone: {patient_data.get('phone_number', 'N/A')}")
         for action_label, action_func in actions.items():
@@ -142,7 +142,7 @@ def handle_create_patient(data, assistant_id):
         new_patient = PatientQueries.create_patient(data, created_by_id=assistant_id)
         if new_patient:
             show_success_message(f"Patient {new_patient['first_name']} {new_patient['last_name']} registered (ID: {new_patient['id']}).")
-            st.session_state.patient_form_data = {} 
+            st.session_state.patient_form_data = {}
         else: show_error_message("Failed to register patient.")
     except Exception as e: show_error_message(f"Error: {e}")
 
@@ -151,10 +151,10 @@ def handle_update_patient(patient_id, data, assistant_id):
         updated_patient = PatientQueries.update_patient(patient_id, data, updated_by_id=assistant_id)
         if updated_patient:
             show_success_message(f"Patient {updated_patient['first_name']} {updated_patient['last_name']} updated.")
-            st.session_state.editing_patient_id = None 
+            st.session_state.editing_patient_id = None
             st.session_state.patient_form_data = {}
             st.session_state.active_patient_management_tab_key = "Search & Manage Patients" # Request tab switch
-            st.rerun() 
+            st.rerun()
         else: show_error_message("Failed to update patient.")
     except Exception as e: show_error_message(f"Error: {e}")
 
@@ -163,15 +163,15 @@ def render_search_manage_patients_tab(assistant: dict):
     # Note: SearchFormComponent mock directly uses session_state.patient_search_term_main
     search_form = SearchFormComponent(session_state_key="patient_search_term_main", label="Search by Name, ID, or Phone:")
     search_form.render()
-    
+
     search_term_val = st.session_state.get("patient_search_term_main", "")
 
     if st.button("🔍 Search Patients", key="search_patients_btn_main"):
         perform_search = True
     elif not search_term_val: # If no search term, show all managed by assistant by default
-        perform_search = True 
+        perform_search = True
     else: # Only search if term exists (button not strictly needed if we want live search, but good for explicit action)
-        perform_search = False 
+        perform_search = False
 
     patients_list = []
     if perform_search or search_term_val: # Search if button clicked OR if there's a search term already
@@ -179,7 +179,7 @@ def render_search_manage_patients_tab(assistant: dict):
             patients_list = PatientQueries.search_patients(search_term=search_term_val, created_by=assistant['id'])
         except Exception as e:
             show_error_message(f"Error searching: {e}")
-    
+
     if not patients_list and (perform_search or search_term_val):
         st.info(f"No patients found matching '{search_term_val}' that you manage.")
     elif not patients_list and not search_term_val :
@@ -187,11 +187,11 @@ def render_search_manage_patients_tab(assistant: dict):
 
 
     for patient_item in patients_list:
-        def edit_action_fn(p_data=patient_item): 
+        def edit_action_fn(p_data=patient_item):
             st.session_state.editing_patient_id = p_data['id']
             full_details = PatientQueries.get_patient_details(p_data['id'])
             st.session_state.patient_form_data = full_details if full_details else p_data
-            st.session_state.active_patient_management_tab_key = "Register / Edit Patient" 
+            st.session_state.active_patient_management_tab_key = "Register / Edit Patient"
             st.rerun()
 
         PatientCard(patient_data=patient_item, actions={"Edit Details": edit_action_fn}, key=f"pat_card_{patient_item['id']}")
@@ -199,14 +199,14 @@ def render_search_manage_patients_tab(assistant: dict):
 
 def render_register_edit_patient_tab(assistant: dict):
     edit_mode_flag = st.session_state.editing_patient_id is not None
-    
+
     header_txt = f"Edit Patient: {st.session_state.patient_form_data.get('first_name', '')} {st.session_state.patient_form_data.get('last_name', '')}" if edit_mode_flag else "Register New Patient"
     st.subheader(header_txt)
 
     patient_form_component = PatientFormComponent(
-        edit_mode=edit_mode_flag, 
+        edit_mode=edit_mode_flag,
         patient_data=st.session_state.patient_form_data,
-        key_prefix="main_pat_form" 
+        key_prefix="main_pat_form"
     )
     submitted_form_data = patient_form_component.render()
 
@@ -219,13 +219,13 @@ def render_register_edit_patient_tab(assistant: dict):
             st.rerun()
         elif edit_mode_flag:
             handle_update_patient(st.session_state.editing_patient_id, submitted_form_data, assistant['id'])
-        else: 
+        else:
             handle_create_patient(submitted_form_data, assistant['id'])
             # Form data is cleared within handle_create_patient. To switch tab:
             # st.session_state.active_patient_management_tab_key = "Search & Manage Patients"; st.rerun()
 
     # "Cancel Edit" button if in edit mode and form hasn't been submitted for cancellation yet
-    if edit_mode_flag and not submitted_form_data: 
+    if edit_mode_flag and not submitted_form_data:
         if st.button("Cancel Edit Mode", key="cancel_edit_mode_btn_main"):
             st.session_state.editing_patient_id = None
             st.session_state.patient_form_data = {}
@@ -237,7 +237,7 @@ def show_patient_management_page():
     require_role_access([USER_ROLES['ASSISTANT']])
     inject_css()
     st.markdown("<h1>👤 Patient Management</h1>", unsafe_allow_html=True)
-    
+
     current_user = get_current_user()
     if not current_user:
         show_error_message("Assistant user data not found."); return
@@ -245,23 +245,23 @@ def show_patient_management_page():
     if 'editing_patient_id' not in st.session_state: st.session_state.editing_patient_id = None
     if 'patient_form_data' not in st.session_state: st.session_state.patient_form_data = {}
     if 'patient_search_term_main' not in st.session_state: st.session_state.patient_search_term_main = "" # Specific key for search
-    if 'active_patient_management_tab_key' not in st.session_state: 
+    if 'active_patient_management_tab_key' not in st.session_state:
         st.session_state.active_patient_management_tab_key = "Search & Manage Patients"
 
     tab_titles_list = ["Search & Manage Patients", "Register / Edit Patient"]
-    
+
     # Determine default tab based on state
     if st.session_state.editing_patient_id: # If editing, force to second tab
         st.session_state.active_patient_management_tab_key = tab_titles_list[1]
-    
+
     # Create tabs. Streamlit's default tab is always the first unless keys change or it's handled differently.
     # The programmatic switch is tricky. Best user experience is often to let user click.
     # Forcing tab switch on action (like 'Edit') is done by st.rerun() after setting state.
-    
+
     # Use a non-persisted variable for default_index for st.tabs if needed, but st.tabs doesn't have it.
     # Instead, we rely on the fact that when "Edit" is clicked, a rerun happens,
     # and the content of the "Register / Edit Patient" tab will reflect the edit mode.
-    
+
     tab1, tab2 = st.tabs(tab_titles_list)
 
     with tab1:
@@ -273,7 +273,7 @@ def show_patient_management_page():
 if __name__ == "__main__":
     if 'user' not in st.session_state:
         st.session_state.user = {
-            'id': 'assistant123', 'username': 'med_assistant_jane', 
+            'id': 'assistant123', 'username': 'med_assistant_jane',
             'role': USER_ROLES['ASSISTANT'], 'full_name': 'Jane Doe (Assistant)',
             'email': 'jane.assistant@example.com'}
         st.session_state.authenticated = True
@@ -282,9 +282,9 @@ if __name__ == "__main__":
     if 'editing_patient_id' not in st.session_state: st.session_state.editing_patient_id = None
     if 'patient_form_data' not in st.session_state: st.session_state.patient_form_data = {}
     if 'patient_search_term_main' not in st.session_state: st.session_state.patient_search_term_main = ""
-    if 'active_patient_management_tab_key' not in st.session_state: 
+    if 'active_patient_management_tab_key' not in st.session_state:
         st.session_state.active_patient_management_tab_key = "Search & Manage Patients"
-    
+
     if not COMPONENTS_AVAILABLE: st.sidebar.warning("Using MOCK UI components.")
     if not DB_QUERIES_AVAILABLE: st.sidebar.warning("Using MOCK DB Queries.")
 


### PR DESCRIPTION
This commit updates `main.py` to use `st.sidebar.markdown()` for generating sidebar navigation links, replacing the previous use of `st.sidebar.page_link()`.

This change addresses an incompatibility with Streamlit versions older than 1.32.0, where `st.sidebar.page_link()` is not available.

The updated logic in `main.py` now:
-   Retrieves the list of allowed pages for the authenticated user's
    role from `auth.permissions.get_allowed_navigation_items()`.
-   For each allowed page, constructs a relative URL from the file path
    (e.g., 'pages/1_doctor_dashboard.py' becomes '1_doctor_dashboard').
-   Renders a markdown link in the sidebar using
    `st.sidebar.markdown(f"- [ICON LABEL](URL)", unsafe_allow_html=True)`.

This should provide working role-based navigation in the sidebar, compatible with Streamlit 1.28.1, and ensure the sidebar remains hidden on the login page due to previously implemented CSS injection.